### PR TITLE
fix(agents): TMPDIR must not be dot-led

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -307,7 +307,7 @@ _rp_write_plist() {
     <key>npm_config_cache</key>
     <string>${dir}/.npm-cache</string>
     <key>TMPDIR</key>
-    <string>${dir}/.tmp</string>
+    <string>${dir}/tmp</string>
 PLIST
     if [ -n "${hook}" ]; then
       cat <<PLIST
@@ -342,6 +342,14 @@ PLIST
 # running app, so a job that leaks there cannot be swept safely; one test suite
 # once left 633k directories and 178GB behind. Pointing each runner at its own
 # temp makes that leak collectable, which is what 'runpool clean' collects.
+#
+# TMPDIR is deliberately NOT dot-led, unlike the caches beside it. Library code
+# roots things at os.tmpdir() without knowing where that points, and a dotted
+# component in the absolute path silently disables anything applying
+# dotfile-ignore rules to it. A file watcher rooted there ignored its whole tree
+# and failed every run of one repository's suite for eight days, load
+# independent, before anyone traced it to the path. The caches keep their dots
+# because only npm and pnpm read them, and neither walks its own cache.
 
 # Regenerate every pool's agents from its config. A running pool picks the
 # change up on its next down/up; a stopped pool on its next up.

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -227,13 +227,21 @@ _rp_clean() {
 
       # Per-runner temp. Safe to wipe wholesale: nothing but this runner's own
       # jobs ever writes here, which is the entire reason it is redirected.
-      td="${rd}/.tmp"
-      if [ -d "${td}" ]; then
-        sz=$(du -sk "${td}" 2>/dev/null | awk '{print $1}')
-        find "${td:?}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null
-        freed_kb=$(( freed_kb + ${sz:-0} ))
-      fi
-      mkdir -p "${td}" 2>/dev/null
+      #
+      # Both names are swept. TMPDIR moved from '.tmp' to 'tmp' because a dotted
+      # component in the absolute path silently disables anything applying
+      # dotfile-ignore rules to it. An install predating the rename still holds
+      # the old directory, which would otherwise sit uncollected forever.
+      for td in "${rd}/tmp" "${rd}/.tmp"; do
+        if [ -d "${td}" ]; then
+          sz=$(du -sk "${td}" 2>/dev/null | awk '{print $1}')
+          find "${td:?}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null
+          freed_kb=$(( freed_kb + ${sz:-0} ))
+        fi
+      done
+      # The legacy directory goes for good once emptied; the current one stays.
+      rmdir "${rd}/.tmp" 2>/dev/null
+      mkdir -p "${rd}/tmp" 2>/dev/null
 
       # Runner diagnostics. Rotated loosely and reaching ~150MB per runner. Job
       # logs live in the GitHub UI, so nothing here is the only copy.


### PR DESCRIPTION
Closes #16. Found by another session tracing why one repository's suite had failed every CI run for eight days.

**The dot was never load-bearing.** Redirecting TMPDIR away from the shared `/var/folders` temp is deliberate and stays, because a job that leaks into the shared temp cannot be swept safely. Naming the target `.tmp` rather than `tmp` was incidental tidiness, and it silently breaks any tool that applies dotfile-ignore rules to an absolute path rooted at `os.tmpdir()`.

It fails by ignoring everything rather than erroring, which is why it survived both a machine-contention explanation and a timeout raised more than fourfold.

**`clean` now sweeps both names** so an install predating this does not orphan its old directory, and removes the legacy one once empty. On this machine that is about 1.4GB across four runners.

**The package caches keep their dots.** Only npm and pnpm read those and neither walks its own cache, so the hazard does not apply. The asymmetry is commented so it does not read as an oversight.

**Applying it to a live install needs `runpool rewrite-agents` and a restart cycle**, since the environment lives in the launch agent. Not done here.