### PR TITLE
feat(apply): describe a machine's pools in a file and reconcile to it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,10 @@ Break any of these and the tool stops being what it is.
 bin/runpool          the executable and its dispatcher
 lib/common.sh        config, logging, pool loading, launch agents, deregistration
 lib/lifecycle.sh     register, set-count, up, down, reregister, remove
+lib/apply.sh         the pools file, and reconciling the machine to it
 lib/scheduler.sh     status, autoscale, sweep, clean, schedule
 lib/notify.sh        the optional notifier hook and what triggers it
+lib/stats.sh         job durations from recorded telemetry
 contrib/             optional pieces the user opts into: job hook, webhook notifier,
                      demo status fixture
 skills/runpool/      agent skill for *using* runpool, shipped with the tool
@@ -63,7 +65,9 @@ The background is transparent and there are no baked-in rounded corners, so the 
 
 ## Configuration precedence
 
-Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **If you add a setting, add it to both lists**, or it silently becomes un-overridable.
+Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **A new setting has to be added in four places in that block** — the snapshot, the restore, the `unset`, and the `export` — or it silently becomes un-overridable, or leaks a `_rp_env_*` variable, or fails to reach a child process.
+
+`RUNPOOL_POOLS_FILE` is deliberately derived from `XDG_CONFIG_HOME` rather than from `RUNPOOL_CONFIG`'s directory, so that pointing the config at `/dev/null` to isolate a test does not also move the pools file somewhere unexpected.
 
 ## Working on it
 
@@ -84,7 +88,9 @@ docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
 RUNPOOL_BASE=/tmp/rp-test RUNPOOL_CONFIG=/dev/null ./bin/runpool status --json
 ```
 
-**Anything that registers, resizes or removes a pool talks to the real GitHub API and to real runners.** There is no dry-run. Verify destructive changes against a throwaway private repository, and never while a job is in flight — the tool refuses on purpose, and forcing past that kills live jobs.
+**Anything that registers, resizes or removes a pool talks to the real GitHub API and to real runners.** `register`, `set-count`, `reregister` and `remove` have no dry-run and there is nowhere sensible to add one, because the work *is* the API call. Verify destructive changes against a throwaway private repository, and never while a job is in flight — the tool refuses on purpose, and forcing past that kills live jobs.
+
+**`apply --dry-run` is the one exception, and only for the plan.** It reads the pools file and the pool configs, prints what it would do, and calls nothing. That makes the whole of `lib/apply.sh` testable with hand-made pool configs under a scratch `RUNPOOL_BASE` and no GitHub account at all. Note what it does *not* cover: a repository's visibility is checked inside `register`, which a dry run never reaches, so a `+` line is a plan and not a promise.
 
 ## Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ assets/icon.svg      the icon, source of truth; PNGs are rendered from it
 
 **`skills/runpool/SKILL.md` and this file have different audiences and must not converge.** This file is for changing runpool. The skill is for an agent wiring some other repository to it, choosing a scope, or working out why a job is queued and nothing has picked it up. If a change alters observable behaviour, the skill needs updating; if it alters how the code is structured, this file does.
 
-**The three-way split is load-bearing**, not cosmetic. It is what lets the notifier be absent. Keep new code in the part that owns the concern; if something does not fit, that is a signal the concern is new, not that the split is wrong.
+**The split by concern is load-bearing**, not cosmetic. It is what lets the notifier be absent, and what keeps the pools file out of everything that does not read one. Keep new code in the part that owns the concern; if something does not fit, that is a signal the concern is new, not that the split is wrong.
 
 ## The icon
 
@@ -67,7 +67,7 @@ The background is transparent and there are no baked-in rounded corners, so the 
 
 Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **A new setting has to be added in four places in that block** — the snapshot, the restore, the `unset`, and the `export` — or it silently becomes un-overridable, or leaks a `_rp_env_*` variable, or fails to reach a child process.
 
-`RUNPOOL_POOLS_FILE` is deliberately derived from `XDG_CONFIG_HOME` rather than from `RUNPOOL_CONFIG`'s directory, so that pointing the config at `/dev/null` to isolate a test does not also move the pools file somewhere unexpected.
+`RUNPOOL_POOLS_FILE` is deliberately derived from `XDG_CONFIG_HOME` rather than from `RUNPOOL_CONFIG`'s directory, so that pointing the config at `/dev/null` to isolate a test does not also move the pools file somewhere unexpected. **The corollary is that neither `RUNPOOL_CONFIG` nor `RUNPOOL_BASE` isolates it** — it has to be set on its own, or overridden per run with `apply --file`. `/dev/null` is a valid value: `apply` tests for a readable non-directory rather than a regular file, so the isolation idiom means the same thing for both settings.
 
 ## Working on it
 
@@ -88,9 +88,11 @@ docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
 RUNPOOL_BASE=/tmp/rp-test RUNPOOL_CONFIG=/dev/null ./bin/runpool status --json
 ```
 
+**`RUNPOOL_BASE` does not move the pools file**, by the design noted under *Configuration precedence* above. Anything touching `apply` needs `RUNPOOL_POOLS_FILE` or `--file` as well, or it reads the real one and plans against real GitHub targets. `RUNPOOL_LOG_DIR` too, or the log lands in a real installation's.
+
 **Anything that registers, resizes or removes a pool talks to the real GitHub API and to real runners.** `register`, `set-count`, `reregister` and `remove` have no dry-run and there is nowhere sensible to add one, because the work *is* the API call. Verify destructive changes against a throwaway private repository, and never while a job is in flight — the tool refuses on purpose, and forcing past that kills live jobs.
 
-**`apply --dry-run` is the one exception, and only for the plan.** It reads the pools file and the pool configs, prints what it would do, and calls nothing. That makes the whole of `lib/apply.sh` testable with hand-made pool configs under a scratch `RUNPOOL_BASE` and no GitHub account at all. Note what it does *not* cover: a repository's visibility is checked inside `register`, which a dry run never reaches, so a `+` line is a plan and not a promise.
+**`apply --dry-run` is the one exception, and only for the plan.** It reads the pools file and the pool configs, prints what it would do, and calls nothing. That makes the whole of `lib/apply.sh` testable with hand-made pool configs under a scratch `RUNPOOL_BASE`, a scratch `RUNPOOL_POOLS_FILE`, and no GitHub account at all. Note what it does *not* cover: a repository's visibility is checked inside `register`, which a dry run never reaches, so a `+` line is a plan and not a promise.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,20 @@ Most changes need runners, which means a GitHub account and a Mac. Two things ma
 
 - **`contrib/demo-status.sh`** answers `status` with invented pools, so anything consuming the JSON can be developed with no runners at all.
 - **`RUNPOOL_BASE`** points RunPool at a scratch directory, so you can register throwaway pools without touching a real setup. Environment beats config, deliberately, so a single invocation can be isolated. Set `RUNPOOL_LOG_DIR` alongside it: the log defaults to `~/Library/Logs/runpool` and a test will otherwise write into a real installation's log.
-- **`runpool apply --dry-run`** calls nothing and changes nothing, so all of `lib/apply.sh` can be exercised against hand-written pool config files under a scratch `RUNPOOL_BASE`, with no GitHub account.
+- **`RUNPOOL_POOLS_FILE`, or `apply --file PATH`, as well.** `RUNPOOL_BASE` does **not** move the pools file: that is derived from `XDG_CONFIG_HOME`, deliberately, so that isolating the config does not lose it. Isolate the base and forget this one and `runpool apply` reads your **real** pools file and tries to register every pool in it into the scratch base — with real registrations against real GitHub targets.
+- **`runpool apply --dry-run`** calls nothing and changes nothing, so all of `lib/apply.sh` can be exercised against hand-written pool config files with no GitHub account.
+
+Which makes the whole isolated invocation:
+
+```bash
+RUNPOOL_BASE=/tmp/rp-test \
+RUNPOOL_LOG_DIR=/tmp/rp-test/logs \
+RUNPOOL_CONFIG=/dev/null \
+RUNPOOL_POOLS_FILE=/tmp/rp-test/pools \
+  ./bin/runpool apply --dry-run
+```
+
+`/dev/null` is a valid value for both of those: the config assigns nothing and the pools file declares no pools.
 
 ## Commits and pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
 Most changes need runners, which means a GitHub account and a Mac. Two things make that less painful:
 
 - **`contrib/demo-status.sh`** answers `status` with invented pools, so anything consuming the JSON can be developed with no runners at all.
-- **`RUNPOOL_BASE`** points RunPool at a scratch directory, so you can register throwaway pools without touching a real setup. Environment beats config, deliberately, so a single invocation can be isolated.
+- **`RUNPOOL_BASE`** points RunPool at a scratch directory, so you can register throwaway pools without touching a real setup. Environment beats config, deliberately, so a single invocation can be isolated. Set `RUNPOOL_LOG_DIR` alongside it: the log defaults to `~/Library/Logs/runpool` and a test will otherwise write into a real installation's log.
+- **`runpool apply --dry-run`** calls nothing and changes nothing, so all of `lib/apply.sh` can be exercised against hand-written pool config files under a scratch `RUNPOOL_BASE`, with no GitHub account.
 
 ## Commits and pull requests
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 
 | Command | |
 |---|---|
-| `register <pool> --repo OWNER/REPO\|--org ORG [--count N] [--allow-public]` | Create a pool and configure its runners |
+| `register <pool> --repo OWNER/REPO\|--org ORG [--count N] [--watch OWNER/REPO,...] [--allow-public]` | Create a pool and configure its runners |
 | `set-count <pool> N` | Change a pool's runner count |
-| `apply [--dry-run]` | Reconcile the machine to a file describing its pools |
+| `apply [--dry-run] [--file PATH]` | Reconcile the machine to a file describing its pools |
 | `up` / `down <pool>` | Bring a pool online, or stand it down |
 | `status [--json]` | Local state alongside what GitHub actually sees |
 | `pools` | List registered pools |
@@ -95,11 +95,17 @@ runpool apply
   ? old          repo me/retired        not in the file — left alone ('runpool remove old' to delete it)
 ```
 
+A real run prints that same plan in full first, then acts on it under an `applying:` heading, so what was decided and what was done stay separate.
+
+**The file is `~/.config/runpool/pools` unless you say otherwise.** `--file PATH` overrides it for one run and `RUNPOOL_POOLS_FILE` overrides it for good, the same precedence as every other setting: environment, then config file, then the default.
+
+**A `#` comments out the line it is on and nothing else**, and a trailing `\` continues onto the next line — which then has to say something. Uncomment a multi-line pool entirely or not at all; half of one is an error naming both lines, not a pool quietly missing the other half.
+
 **Reconciliation goes one way.** A pool in the file and not on the machine is created, a count or watch list that differs is changed, and **a pool on the machine and not in the file is reported and left alone**. Deleting a pool deregisters its runners with GitHub, and a missing line is far too quiet a way to ask for that, so `remove` stays explicit. Changing a pool's scope or target is reported as a conflict rather than applied, because the runners are registered against the old one.
 
 The file holds no credentials and nothing machine-specific, so **a second machine gets the same pools by getting the same file.** That is the point of it: `register` does not become wrong, it just stops being the thing you copy.
 
-**`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. It is the one setting `register` cannot express ([#19](https://github.com/aicayzer/runpool/issues/19)).
+**`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. `register` takes it too, so a single pool created by hand is no worse off than one from the file; on a repo pool both refuse it, because such a pool already polls its own target.
 
 ## Raycast extension
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 |---|---|
 | `register <pool> --repo OWNER/REPO\|--org ORG [--count N] [--allow-public]` | Create a pool and configure its runners |
 | `set-count <pool> N` | Change a pool's runner count |
+| `apply [--dry-run]` | Reconcile the machine to a file describing its pools |
 | `up` / `down <pool>` | Bring a pool online, or stand it down |
 | `status [--json]` | Local state alongside what GitHub actually sees |
 | `pools` | List registered pools |
@@ -68,6 +69,37 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 **`status --json --local` skips the GitHub query**, reporting those fields as `null`. Anything refreshing on a timer should use it: one API call per pool per minute is thousands a day, and it makes a passive readout fail whenever the network does.
 
 `skills/runpool/` is an agent skill for *using* RunPool: wiring a repository to local CI, choosing a scope, and diagnosing a job that queues and never starts.
+
+## Describing a machine's pools
+
+`register` creates one pool from one command, which is the right way to add one pool and the wrong way to describe a machine: the setup then exists only as a sequence somebody remembers running. Put it in `~/.config/runpool/pools` instead, one pool per line, written as its `register` arguments minus the word `register`:
+
+```
+acme  --org acme-inc --count 4 \
+      --watch acme-inc/api, acme-inc/web
+
+side  --repo me/side-project --count 1
+```
+
+```bash
+runpool apply --dry-run   # what would change
+runpool apply
+```
+
+**Reach for `--dry-run` first.** It prints the plan and touches nothing:
+
+```
+  ~ acme         org  acme-inc          count 2 -> 4; watch (none) -> acme-inc/api,acme-inc/web
+  = side         repo me/side-project   up to date (1 runner(s))
+  + build        org  acme-inc          create with 2 runner(s)
+  ? old          repo me/retired        not in the file — left alone ('runpool remove old' to delete it)
+```
+
+**Reconciliation goes one way.** A pool in the file and not on the machine is created, a count or watch list that differs is changed, and **a pool on the machine and not in the file is reported and left alone**. Deleting a pool deregisters its runners with GitHub, and a missing line is far too quiet a way to ask for that, so `remove` stays explicit. Changing a pool's scope or target is reported as a conflict rather than applied, because the runners are registered against the old one.
+
+The file holds no credentials and nothing machine-specific, so **a second machine gets the same pools by getting the same file.** That is the point of it: `register` does not become wrong, it just stops being the thing you copy.
+
+**`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. It is the one setting `register` cannot express ([#19](https://github.com/aicayzer/runpool/issues/19)).
 
 ## Raycast extension
 

--- a/bin/runpool
+++ b/bin/runpool
@@ -35,6 +35,8 @@ export RUNPOOL_SELF
 . "${RUNPOOL_ROOT}/lib/common.sh"
 # shellcheck source=lib/lifecycle.sh
 . "${RUNPOOL_ROOT}/lib/lifecycle.sh"
+# shellcheck source=lib/apply.sh
+. "${RUNPOOL_ROOT}/lib/apply.sh"
 # shellcheck source=lib/scheduler.sh
 . "${RUNPOOL_ROOT}/lib/scheduler.sh"
 # shellcheck source=lib/notify.sh
@@ -50,6 +52,11 @@ runpool — on-demand self-hosted GitHub Actions runner pools for macOS
                            create a pool and configure its runners (left stopped)
                            a public repo is refused; --allow-public overrides it
   set-count <pool> N       change a pool's runner count after registration
+  apply [--dry-run] [--file PATH]
+                           reconcile this machine to a file describing its
+                           pools: create what is missing, resize what differs,
+                           report what is not in the file. Never deletes.
+                           --dry-run prints the plan and changes nothing
   up|down <pool>           bring a pool online / stand it down
   up-all|down-all          every pool
   status [--json] [--local]
@@ -70,6 +77,7 @@ Routing lives in each repository's workflow (runs-on), not here. This tool
 controls only whether runners are running.
 
 Configuration: ~/.config/runpool/config  (see runpool.conf.example)
+Pools:         ~/.config/runpool/pools   (see runpool.pools.example)
 HELP
 }
 
@@ -77,6 +85,7 @@ cmd="${1:-}"; [ $# -gt 0 ] && shift
 case "${cmd}" in
   register)       _rp_register "$@" ;;
   set-count)      _rp_set_count "$@" ;;
+  apply)          _rp_apply "$@" ;;
   reregister)     _rp_reregister "$@" ;;
   up)             _rp_up "$@" ;;
   down)           _rp_down "$@" ;;

--- a/bin/runpool
+++ b/bin/runpool
@@ -48,9 +48,13 @@ _rp_help() {
   cat <<'HELP'
 runpool — on-demand self-hosted GitHub Actions runner pools for macOS
 
-  register <pool> --repo OWNER/REPO|--org ORG [--count N] [--allow-public]
+  register <pool> --repo OWNER/REPO|--org ORG [--count N]
+                  [--watch OWNER/REPO,...] [--allow-public]
                            create a pool and configure its runners (left stopped)
+                           --watch is org pools only: the repositories polled
+                           for queued work, without which one never autoscales
                            a public repo is refused; --allow-public overrides it
+                           (repo scope only)
   set-count <pool> N       change a pool's runner count after registration
   apply [--dry-run] [--file PATH]
                            reconcile this machine to a file describing its
@@ -78,6 +82,7 @@ controls only whether runners are running.
 
 Configuration: ~/.config/runpool/config  (see runpool.conf.example)
 Pools:         ~/.config/runpool/pools   (see runpool.pools.example)
+               override with RUNPOOL_POOLS_FILE, or per run with --file
 HELP
 }
 

--- a/install.sh
+++ b/install.sh
@@ -42,12 +42,25 @@ else
   echo "kept existing ${CONFIG_DIR}/config"
 fi
 
+# No chmod here, unlike the config above: the pools file holds no credentials,
+# which is the whole reason it is safe to copy between machines.
+if [ ! -f "${CONFIG_DIR}/pools" ]; then
+  cp "${ROOT}/runpool.pools.example" "${CONFIG_DIR}/pools"
+  echo "wrote ${CONFIG_DIR}/pools (a commented template, declaring nothing yet)"
+else
+  echo "kept existing ${CONFIG_DIR}/pools"
+fi
+
 cat <<'NEXT'
 
 Next:
   runpool register <pool> --repo OWNER/REPO   # or --org ORG
   runpool schedule install                    # background autoscale and clean
   runpool status
+
+Or describe every pool in ~/.config/runpool/pools and reconcile to it:
+  runpool apply --dry-run                     # what would change
+  runpool apply
 
 Pools come up on their own when a job queues. Nothing starts at login.
 NEXT

--- a/lib/apply.sh
+++ b/lib/apply.sh
@@ -29,6 +29,10 @@
 # Blank lines and '#' comments are ignored, and a trailing '\' continues onto
 # the next line, which is what keeps a long --watch list readable.
 #
+# A '#' comments out the line it is on and nothing else, including when that
+# line ends in '\'. See the comment on the stripping below: the other reading
+# is what let a commented-out example silently rewrite the pool after it.
+#
 # Parsed by hand rather than sourced. The config file is sourced because it
 # assigns shell variables and there is no other sensible way to read it; this
 # file is meant to be copied between machines and read by whoever inherits it,
@@ -50,20 +54,47 @@
 # file would expand to whatever happens to be in the current directory.
 _rp_parse_pools_file() (
   set -f
-  local file="$1" line acc="" lineno=0 declared=" " count_declared=0 \
-        name scope target count watch allow tok val
+  local file="$1" line acc="" acc_line=0 lineno=0 declared=" " count_declared=0 \
+        name scope target count watch allow clean rest tok val
 
   while IFS= read -r line || [ -n "${line}" ]; do
     lineno=$(( lineno + 1 ))
 
-    # Continuation is handled before comment stripping, so that a '#' later on
-    # the joined line still comments out the rest of it.
-    case "${line}" in
-      *\\) acc="${acc}${line%\\} "; continue ;;
-    esac
-    line="${acc}${line}"; acc=""
-
+    # Comments are stripped per PHYSICAL line, before the trailing '\' is
+    # looked at. The other order — continue first, strip the joined line —
+    # reads a commented line ending in '\' as a continuation, and the '#'
+    # then eats whatever it was joined to. The shipped template taught exactly
+    # that: two commented lines, the first ending in '\'. Uncommenting only
+    # the first produced a pool with NO watch list, which is precisely the
+    # never-autoscales state this whole feature exists to prevent; uncommenting
+    # only the second produced "declares no pools" and exit 0. Both silent,
+    # both a different pool from the one the file appears to declare.
+    #
+    # Stripping first costs nothing that was worth having: a trailing comment
+    # still works on any physical line, including the last of a continuation.
+    # All that is lost is a '#' on one line commenting out the next, which is
+    # not what '#' means anywhere else.
     line="${line%%#*}"
+
+    case "${line}" in
+      *\\)
+        [ -n "${acc}" ] || acc_line="${lineno}"
+        acc="${acc}${line%\\} "
+        continue ;;
+    esac
+
+    # A continuation has to land on a line that still says something. It used
+    # to be allowed to land on a blank or a comment, quietly ending the pool
+    # early and dropping every flag the author clearly meant to be part of it.
+    if [ -n "${acc}" ]; then
+      rest="${line// /}"; rest="${rest//$'\t'/}"
+      [ -n "${rest}" ] || {
+        _rp_err "${file}:${lineno}: nothing here to continue the pool started on line ${acc_line}"
+        _rp_err "A trailing '\\' continues onto the next line; a blank line or a comment cannot be that line."
+        return 1
+      }
+    fi
+    line="${acc}${line}"; acc=""
 
     # Collapse ', ' to ',' so a watch list can be written the way anyone would
     # naturally write one. Word splitting is the tokeniser, so without this
@@ -82,6 +113,14 @@ _rp_parse_pools_file() (
     [ $# -gt 0 ] || continue
 
     name="$1"; shift
+    # A line starting with a flag is almost always a continuation line whose
+    # opening line is commented out, and 'invalid pool name' is a poor way to
+    # say so. '--watch' passes _rp_valid_pool_name on its characters.
+    case "${name}" in
+      -*) _rp_err "${file}:${lineno}: expected a pool name, got '${name}'"
+          _rp_err "A flag can only continue a line ending in '\\'. Is the line above it commented out?"
+          return 1 ;;
+    esac
     _rp_valid_pool_name "${name}" || {
       _rp_err "${file}:${lineno}: invalid pool name '${name}'"
       _rp_err "Letters, digits, dot, underscore and hyphen only."
@@ -113,8 +152,7 @@ _rp_parse_pools_file() (
             --watch) watch="${watch},${val}" ;;
           esac
           ;;
-        --allow-public) allow="1"; shift ;;
-        *) _rp_err "${file}:${lineno}: unknown field '${tok}'"; return 1 ;;
+        --allow-public) allow="1"; shift ;;        *) _rp_err "${file}:${lineno}: unknown field '${tok}'"; return 1 ;;
       esac
     done
 
@@ -129,10 +167,25 @@ _rp_parse_pools_file() (
         _rp_err "${file}:${lineno}: '${target}' is not OWNER/REPO"; return 1; }
     fi
 
-    case "${count}" in
-      ''|*[!0-9]*) _rp_err "${file}:${lineno}: count must be a positive integer, got '${count}'"; return 1 ;;
-    esac
-    [ "${count}" -ge 1 ] || { _rp_err "${file}:${lineno}: count must be at least 1"; return 1; }
+    # Shared with `register` rather than repeated, so the pools file and the
+    # command line cannot disagree about what a count is. This used to test
+    # only for non-digits, which let '007' through to POOL_COUNT and out again
+    # as invalid JSON, and let an over-long number through to a raw
+    # 'integer expression expected' from `[ -ge ]`.
+    _rp_valid_count "${count}" || {
+      _rp_err "${file}:${lineno}: count: $(_rp_count_rule), got '${count}'"; return 1; }
+
+    # --allow-public is refused at org scope for the same reason --watch is
+    # refused at repo scope, one paragraph down: it does nothing there, and a
+    # flag that silently does nothing is how a file ends up saying something
+    # the machine never agreed to. `register` consults it only under repo
+    # scope, because at org scope the control is GitHub's
+    # allows_public_repositories on the runner group. See SECURITY.md.
+    if [ "${allow}" = "1" ] && [ "${scope}" = "org" ]; then
+      _rp_err "${file}:${lineno}: --allow-public applies to repo pools only"
+      _rp_err "At organisation scope the equivalent is GitHub's own allows_public_repositories on the runner group."
+      return 1
+    fi
 
     watch="${watch#,}"
     if [ -n "${watch}" ]; then
@@ -144,17 +197,24 @@ _rp_parse_pools_file() (
         _rp_err "${file}:${lineno}: --watch applies to org pools only — a repo pool polls ${target} itself"
         return 1
       }
+      # Rebuilt from the entries that were actually validated, not stored as
+      # written. Splitting on commas drops empty entries before the check, so
+      # ',acme-inc/api' and 'a/b,,c/d' passed validation and were then written
+      # to POOL_WATCH verbatim — approving one string and storing another.
+      clean=""
       for tok in $(echo "${watch}" | tr ',' ' '); do
         _rp_valid_gh_repo "${tok}" || {
           _rp_err "${file}:${lineno}: watched repository '${tok}' is not OWNER/REPO"; return 1; }
+        clean="${clean},${tok}"
       done
+      watch="${clean#,}"
     fi
 
     printf '%s|%s|%s|%s|%s|%s\n' "${name}" "${scope}" "${target}" "${count}" "${watch}" "${allow}"
     count_declared=$(( count_declared + 1 ))
-  done < "${file}"
+  done < "${file}" || { _rp_err "${file}: could not be read"; return 1; }
 
-  [ -z "${acc}" ] || { _rp_err "${file}: ends with a trailing '\\' and nothing to continue onto"; return 1; }
+  [ -z "${acc}" ] || { _rp_err "${file}:${acc_line}: ends with a trailing '\\' and nothing to continue onto"; return 1; }
   [ "${count_declared}" -gt 0 ] || _rp_err "${file}: declares no pools"
   return 0
 )
@@ -168,8 +228,8 @@ _rp_plan_line() { printf "  %s %-12s %-4s %-24s %s\n" "$1" "$2" "$3" "$4" "$5"; 
 
 _rp_apply() {
   # Every local declared once, at the top.
-  local dry=0 file="${RUNPOOL_POOLS_FILE}" records rc=0 seen=" " \
-        name scope target count watch allow \
+  local dry=0 file="${RUNPOOL_POOLS_FILE}" records actions="" rc=0 seen=" " \
+        name scope target count watch allow verb chg_count chg_watch \
         have_count have_watch what p \
         n_create=0 n_change=0 n_same=0 n_conflict=0 n_absent=0 n_failed=0
 
@@ -183,11 +243,24 @@ _rp_apply() {
     esac
   done
 
-  [ -f "${file}" ] || {
+  # Present, then not a directory, then readable — three messages rather than
+  # one, because the three are fixed differently.
+  #
+  # '-e' and '-r' rather than '-f'. A '-f' test refuses /dev/null, which is the
+  # isolation idiom AGENTS.md recommends for RUNPOOL_CONFIG and which ought to
+  # mean the same thing here: a file that declares no pools.
+  #
+  # The readability test is the one that matters. The redirect feeding the
+  # parser was unchecked, so a pools file the user could not read parsed as
+  # zero pools and returned 0 — and every pool actually on the machine was then
+  # reported as '? not in the file', which is the exact inverse of the truth.
+  if [ ! -e "${file}" ]; then
     _rp_err "no pools file at ${file}"
     _rp_err "Write one (runpool.pools.example is a commented template), or pass --file PATH."
     return 1
-  }
+  fi
+  [ ! -d "${file}" ] || { _rp_err "${file} is a directory, not a pools file"; return 1; }
+  [ -r "${file}" ]   || { _rp_err "cannot read ${file} — check its permissions"; return 1; }
 
   # Parsed in full before anything is touched, so a typo on the last line
   # cannot leave the machine half reconciled.
@@ -197,6 +270,14 @@ _rp_apply() {
   [ "${dry}" = "1" ] || echo "  (not a dry run — changes are being made)"
   echo
 
+  # ---- pass one: decide everything and print the whole plan ----------------
+  #
+  # Deciding and acting used to happen together, so each plan line printed
+  # immediately before its own action and `register`'s output landed in the
+  # middle of the plan. A plan interleaved with the consequences of its own
+  # first half is not a plan, and it is not what the README shows either.
+  # Nothing here touches the machine; the actions are collected and run below.
+  #
   # Records arrive on fd 3 rather than stdin. `register` shells out to the
   # runner's config.sh and to gh, and anything in the loop body that read stdin
   # would eat the rest of the plan.
@@ -213,18 +294,8 @@ _rp_apply() {
       [ -n "${watch}" ] && what="${what}, watching ${watch}"
       [ "${allow}" = "1" ] && what="${what} [--allow-public]"
       _rp_plan_line "+" "${name}" "${scope}" "${target}" "${what}"
-      [ "${dry}" = "1" ] && continue
-
-      if [ "${allow}" = "1" ]; then
-        _rp_register "${name}" "--${scope}" "${target}" --count "${count}" --allow-public
-      else
-        _rp_register "${name}" "--${scope}" "${target}" --count "${count}"
-      fi || { n_failed=$(( n_failed + 1 )); rc=1; continue; }
-      # register writes the pool's conf from scratch and takes no --watch, so
-      # the watch list is appended to it here. See issue #19.
-      if [ -n "${watch}" ]; then
-        _rp_write_pool_watch "${name}" "${watch}" || { n_failed=$(( n_failed + 1 )); rc=1; }
-      fi
+      actions="${actions}create|${name}|${scope}|${target}|${count}|${watch}|${allow}|0|0
+"
       continue
     fi
 
@@ -246,9 +317,15 @@ _rp_apply() {
     # after its commas does not read as drift.
     have_watch="$(echo "${POOL_WATCH:-}" | tr -d ' ')"
 
+    # --allow-public is deliberately not compared. It is not pool state and is
+    # not recorded anywhere: it is permission to perform a create, consulted
+    # once by `register` and meaningless afterwards. Adding or removing it on a
+    # pool that already exists changes nothing, so '=' is the truthful answer.
+    chg_count=0; chg_watch=0
     what=""
-    [ "${count}" != "${have_count}" ] && what="count ${have_count} -> ${count}"
+    [ "${count}" != "${have_count}" ] && { chg_count=1; what="count ${have_count} -> ${count}"; }
     if [ "${watch}" != "${have_watch}" ]; then
+      chg_watch=1
       [ -n "${what}" ] && what="${what}; "
       what="${what}watch ${have_watch:-(none)} -> ${watch:-(none)}"
     fi
@@ -261,26 +338,53 @@ _rp_apply() {
 
     n_change=$(( n_change + 1 ))
     _rp_plan_line "~" "${name}" "${scope}" "${target}" "${what}"
-    [ "${dry}" = "1" ] && continue
-
-    if [ "${watch}" != "${have_watch}" ]; then
-      _rp_write_pool_watch "${name}" "${watch}" || { n_failed=$(( n_failed + 1 )); rc=1; }
-    fi
-    if [ "${count}" != "${have_count}" ]; then
-      # Refuses while a job is in flight, and says so. One pool failing that
-      # way must not abandon the rest of the plan.
-      _rp_set_count "${name}" "${count}" || { n_failed=$(( n_failed + 1 )); rc=1; }
-    fi
+    actions="${actions}change|${name}|${scope}|${target}|${count}|${watch}|0|${chg_count}|${chg_watch}
+"
   done 3< <(printf '%s\n' "${records}")
 
   # Pools the machine has and the file does not. Reported, never removed.
   for p in $(_rp_pool_names); do
     case "${seen}" in *" ${p} "*) continue ;; esac
+    # Counted only once the config is known to have loaded. Counting first made
+    # the summary say '2 not in the file' above a single '?' line.
+    _rp_load_pool "${p}" || { n_failed=$(( n_failed + 1 )); rc=1; continue; }
     n_absent=$(( n_absent + 1 ))
-    _rp_load_pool "${p}" || continue
     _rp_plan_line "?" "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" \
       "not in the file — left alone ('runpool remove ${p}' to delete it)"
   done
+
+  # ---- pass two: act on it ------------------------------------------------
+  if [ "${dry}" != "1" ] && [ -n "${actions}" ]; then
+    echo
+    echo "  applying:"
+    while IFS='|' read -r verb name scope target count watch allow chg_count chg_watch <&3; do
+      [ -n "${verb}" ] || continue
+      case "${verb}" in
+        create)
+          # Built as an argument list rather than interpolated, so a watch list
+          # reaches `register` as one word whatever it contains.
+          set -- "${name}" "--${scope}" "${target}" --count "${count}"
+          # register writes POOL_WATCH itself, inside the same file write as
+          # the rest of the pool (#19). It used to be appended here afterwards,
+          # which left a window in which a create could succeed and the watch
+          # list never arrive.
+          [ -n "${watch}" ] && set -- "$@" --watch "${watch}"
+          [ "${allow}" = "1" ] && set -- "$@" --allow-public
+          _rp_register "$@" || { n_failed=$(( n_failed + 1 )); rc=1; }
+          ;;
+        change)
+          if [ "${chg_watch}" = "1" ]; then
+            _rp_write_pool_watch "${name}" "${watch}" || { n_failed=$(( n_failed + 1 )); rc=1; }
+          fi
+          if [ "${chg_count}" = "1" ]; then
+            # Refuses while a job is in flight, and says so. One pool failing
+            # that way must not abandon the rest of the plan.
+            _rp_set_count "${name}" "${count}" || { n_failed=$(( n_failed + 1 )); rc=1; }
+          fi
+          ;;
+      esac
+    done 3< <(printf '%s' "${actions}")
+  fi
 
   echo
   echo "  ${n_create} to create, ${n_change} to change, ${n_same} unchanged, ${n_absent} not in the file"

--- a/lib/apply.sh
+++ b/lib/apply.sh
@@ -1,0 +1,297 @@
+# shellcheck shell=bash
+# apply.sh — reconcile the machine's pools to a file describing them.
+#
+# `register` creates one pool from one command, so a machine's setup exists
+# nowhere except as a sequence somebody ran once. That is fine for one machine
+# and stops being fine at two: the second is a recall exercise rather than a
+# copy, and nothing states what a machine is *meant* to have, so a count
+# changed by hand is indistinguishable from one that was always meant to be
+# that.
+#
+# Reconciliation runs in one direction only. A pool in the file and not on the
+# machine is created; a count or watch list that differs is changed; a pool on
+# the machine and not in the file is reported and left alone. Deleting a pool
+# deregisters its runners with GitHub, and a missing line is far too quiet a
+# way to ask for that, so `remove` stays explicit.
+#
+# `register` stays too. One pool from one command is still the right way to add
+# one pool; this is the alternative for describing a whole machine.
+
+# ---------------------------------------------------------------------------
+# The file format
+# ---------------------------------------------------------------------------
+# One pool per line, written exactly as its `register` arguments minus the word
+# `register`, so there is one vocabulary to learn rather than two:
+#
+#   acme    --org acme-inc --count 4 --watch acme-inc/api,acme-inc/web
+#   side    --repo me/side-project --count 1
+#
+# Blank lines and '#' comments are ignored, and a trailing '\' continues onto
+# the next line, which is what keeps a long --watch list readable.
+#
+# Parsed by hand rather than sourced. The config file is sourced because it
+# assigns shell variables and there is no other sensible way to read it; this
+# file is meant to be copied between machines and read by whoever inherits it,
+# and a file that is also a shell script is a worse thing to copy. Hand parsing
+# is also what lets a bad line name itself by number instead of failing
+# somewhere further on.
+
+# Emit one record per declared pool, fields separated by '|':
+#
+#   name|scope|target|count|watch|allow_public
+#
+# '|' and not a tab: tab is IFS whitespace, so a run of them collapses and an
+# empty field in the middle of a record silently disappears when `read` splits
+# it back out. 'watch' is empty for most pools, which is exactly that case.
+# Every field is validated below to characters that cannot include '|'.
+#
+# The body is a subshell so that 'set -f' cannot leak into the caller. Word
+# splitting is the tokeniser here, and without noglob an unquoted '*' in the
+# file would expand to whatever happens to be in the current directory.
+_rp_parse_pools_file() (
+  set -f
+  local file="$1" line acc="" lineno=0 declared=" " count_declared=0 \
+        name scope target count watch allow tok val
+
+  while IFS= read -r line || [ -n "${line}" ]; do
+    lineno=$(( lineno + 1 ))
+
+    # Continuation is handled before comment stripping, so that a '#' later on
+    # the joined line still comments out the rest of it.
+    case "${line}" in
+      *\\) acc="${acc}${line%\\} "; continue ;;
+    esac
+    line="${acc}${line}"; acc=""
+
+    line="${line%%#*}"
+
+    # Collapse ', ' to ',' so a watch list can be written the way anyone would
+    # naturally write one. Word splitting is the tokeniser, so without this
+    # '--watch a/b, c/d' tokenises as three fields and the third is rejected as
+    # unknown. Each pass replaces the first occurrence; commas appear in no
+    # other field, so nothing else is affected.
+    while :; do
+      case "${line}" in
+        *,\ *) line="${line%%, *},${line#*, }" ;;
+        *) break ;;
+      esac
+    done
+
+    # shellcheck disable=SC2086  # deliberate: this is the tokeniser, noglob is on
+    set -- ${line}
+    [ $# -gt 0 ] || continue
+
+    name="$1"; shift
+    _rp_valid_pool_name "${name}" || {
+      _rp_err "${file}:${lineno}: invalid pool name '${name}'"
+      _rp_err "Letters, digits, dot, underscore and hyphen only."
+      return 1
+    }
+    case "${declared}" in
+      *" ${name} "*) _rp_err "${file}:${lineno}: pool '${name}' is declared more than once"; return 1 ;;
+    esac
+    declared="${declared}${name} "
+
+    scope=""; target=""; count="2"; watch=""; allow="0"
+    while [ $# -gt 0 ]; do
+      tok="$1"
+      case "${tok}" in
+        --org|--repo|--count|--watch)
+          # Checked before shifting two. 'shift 2' with one argument left is a
+          # failure that does not shift, which turns this into an infinite loop
+          # rather than an error.
+          [ $# -ge 2 ] || { _rp_err "${file}:${lineno}: ${tok} needs a value"; return 1; }
+          val="$2"; shift 2
+          case "${tok}" in
+            --org|--repo)
+              [ -z "${scope}" ] || {
+                _rp_err "${file}:${lineno}: give exactly one of --org or --repo"; return 1; }
+              case "${tok}" in --org) scope="org" ;; *) scope="repo" ;; esac
+              target="${val}"
+              ;;
+            --count) count="${val}" ;;
+            --watch) watch="${watch},${val}" ;;
+          esac
+          ;;
+        --allow-public) allow="1"; shift ;;
+        *) _rp_err "${file}:${lineno}: unknown field '${tok}'"; return 1 ;;
+      esac
+    done
+
+    [ -n "${scope}" ] || {
+      _rp_err "${file}:${lineno}: '${name}' needs --org ORG or --repo OWNER/REPO"; return 1; }
+
+    if [ "${scope}" = "org" ]; then
+      _rp_valid_gh_name "${target}" || {
+        _rp_err "${file}:${lineno}: '${target}' is not an organisation name"; return 1; }
+    else
+      _rp_valid_gh_repo "${target}" || {
+        _rp_err "${file}:${lineno}: '${target}' is not OWNER/REPO"; return 1; }
+    fi
+
+    case "${count}" in
+      ''|*[!0-9]*) _rp_err "${file}:${lineno}: count must be a positive integer, got '${count}'"; return 1 ;;
+    esac
+    [ "${count}" -ge 1 ] || { _rp_err "${file}:${lineno}: count must be at least 1"; return 1; }
+
+    watch="${watch#,}"
+    if [ -n "${watch}" ]; then
+      # A repo pool polls its own target and _rp_autoscale never looks at
+      # POOL_WATCH for one, so a watch list here would do nothing at all.
+      # Refused rather than ignored: silently doing nothing is how a pool ends
+      # up never waking and nobody knowing why.
+      [ "${scope}" = "org" ] || {
+        _rp_err "${file}:${lineno}: --watch applies to org pools only — a repo pool polls ${target} itself"
+        return 1
+      }
+      for tok in $(echo "${watch}" | tr ',' ' '); do
+        _rp_valid_gh_repo "${tok}" || {
+          _rp_err "${file}:${lineno}: watched repository '${tok}' is not OWNER/REPO"; return 1; }
+      done
+    fi
+
+    printf '%s|%s|%s|%s|%s|%s\n' "${name}" "${scope}" "${target}" "${count}" "${watch}" "${allow}"
+    count_declared=$(( count_declared + 1 ))
+  done < "${file}"
+
+  [ -z "${acc}" ] || { _rp_err "${file}: ends with a trailing '\\' and nothing to continue onto"; return 1; }
+  [ "${count_declared}" -gt 0 ] || _rp_err "${file}: declares no pools"
+  return 0
+)
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+# One line per pool, in the same columns as `runpool pools`, prefixed by what
+# would happen to it.
+_rp_plan_line() { printf "  %s %-12s %-4s %-24s %s\n" "$1" "$2" "$3" "$4" "$5"; }
+
+_rp_apply() {
+  # Every local declared once, at the top.
+  local dry=0 file="${RUNPOOL_POOLS_FILE}" records rc=0 seen=" " \
+        name scope target count watch allow \
+        have_count have_watch what p \
+        n_create=0 n_change=0 n_same=0 n_conflict=0 n_absent=0 n_failed=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry=1; shift ;;
+      --file)
+        [ $# -ge 2 ] || { _rp_err "--file needs a path"; return 1; }
+        file="$2"; shift 2 ;;
+      *) _rp_err "unknown flag: $1 (usage: runpool apply [--dry-run] [--file PATH])"; return 1 ;;
+    esac
+  done
+
+  [ -f "${file}" ] || {
+    _rp_err "no pools file at ${file}"
+    _rp_err "Write one (runpool.pools.example is a commented template), or pass --file PATH."
+    return 1
+  }
+
+  # Parsed in full before anything is touched, so a typo on the last line
+  # cannot leave the machine half reconciled.
+  records="$(_rp_parse_pools_file "${file}")" || return 1
+
+  echo "plan from ${file}"
+  [ "${dry}" = "1" ] || echo "  (not a dry run — changes are being made)"
+  echo
+
+  # Records arrive on fd 3 rather than stdin. `register` shells out to the
+  # runner's config.sh and to gh, and anything in the loop body that read stdin
+  # would eat the rest of the plan.
+  while IFS='|' read -r name scope target count watch allow <&3; do
+    # A file that declares no pools is a valid state, not an error — but an
+    # empty record set still feeds one empty line through the printf below,
+    # and that reads back as a pool with no name and plans a create for it.
+    [ -n "${name}" ] || continue
+    seen="${seen}${name} "
+
+    if [ ! -f "$(_rp_pool_conf "${name}")" ]; then
+      n_create=$(( n_create + 1 ))
+      what="create with ${count} runner(s)"
+      [ -n "${watch}" ] && what="${what}, watching ${watch}"
+      [ "${allow}" = "1" ] && what="${what} [--allow-public]"
+      _rp_plan_line "+" "${name}" "${scope}" "${target}" "${what}"
+      [ "${dry}" = "1" ] && continue
+
+      if [ "${allow}" = "1" ]; then
+        _rp_register "${name}" "--${scope}" "${target}" --count "${count}" --allow-public
+      else
+        _rp_register "${name}" "--${scope}" "${target}" --count "${count}"
+      fi || { n_failed=$(( n_failed + 1 )); rc=1; continue; }
+      # register writes the pool's conf from scratch and takes no --watch, so
+      # the watch list is appended to it here. See issue #19.
+      if [ -n "${watch}" ]; then
+        _rp_write_pool_watch "${name}" "${watch}" || { n_failed=$(( n_failed + 1 )); rc=1; }
+      fi
+      continue
+    fi
+
+    _rp_load_pool "${name}" || { n_failed=$(( n_failed + 1 )); rc=1; continue; }
+
+    # Scope and target are what the runners are registered against. Changing
+    # either means deregistering every runner and registering it again
+    # somewhere else, which is `remove` followed by `apply`, not something a
+    # reconcile should do behind the operator's back.
+    if [ "${scope}" != "${POOL_SCOPE}" ] || [ "${target}" != "${POOL_TARGET}" ]; then
+      n_conflict=$(( n_conflict + 1 )); rc=1
+      _rp_plan_line "!" "${name}" "${POOL_SCOPE}" "${POOL_TARGET}" \
+        "registered here, but the file says ${scope} ${target} — 'runpool remove ${name}' first"
+      continue
+    fi
+
+    have_count="${POOL_COUNT}"
+    # Normalised the same way both sides, so a hand-edited conf with spaces
+    # after its commas does not read as drift.
+    have_watch="$(echo "${POOL_WATCH:-}" | tr -d ' ')"
+
+    what=""
+    [ "${count}" != "${have_count}" ] && what="count ${have_count} -> ${count}"
+    if [ "${watch}" != "${have_watch}" ]; then
+      [ -n "${what}" ] && what="${what}; "
+      what="${what}watch ${have_watch:-(none)} -> ${watch:-(none)}"
+    fi
+
+    if [ -z "${what}" ]; then
+      n_same=$(( n_same + 1 ))
+      _rp_plan_line "=" "${name}" "${scope}" "${target}" "up to date (${count} runner(s))"
+      continue
+    fi
+
+    n_change=$(( n_change + 1 ))
+    _rp_plan_line "~" "${name}" "${scope}" "${target}" "${what}"
+    [ "${dry}" = "1" ] && continue
+
+    if [ "${watch}" != "${have_watch}" ]; then
+      _rp_write_pool_watch "${name}" "${watch}" || { n_failed=$(( n_failed + 1 )); rc=1; }
+    fi
+    if [ "${count}" != "${have_count}" ]; then
+      # Refuses while a job is in flight, and says so. One pool failing that
+      # way must not abandon the rest of the plan.
+      _rp_set_count "${name}" "${count}" || { n_failed=$(( n_failed + 1 )); rc=1; }
+    fi
+  done 3< <(printf '%s\n' "${records}")
+
+  # Pools the machine has and the file does not. Reported, never removed.
+  for p in $(_rp_pool_names); do
+    case "${seen}" in *" ${p} "*) continue ;; esac
+    n_absent=$(( n_absent + 1 ))
+    _rp_load_pool "${p}" || continue
+    _rp_plan_line "?" "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" \
+      "not in the file — left alone ('runpool remove ${p}' to delete it)"
+  done
+
+  echo
+  echo "  ${n_create} to create, ${n_change} to change, ${n_same} unchanged, ${n_absent} not in the file"
+  [ "${n_conflict}" -gt 0 ] && echo "  ${n_conflict} conflict(s): scope or target differs — see the '!' lines above"
+  [ "${n_failed}" -gt 0 ] && echo "  ${n_failed} failed — see the messages above"
+  if [ "${dry}" = "1" ]; then
+    echo "  dry run: nothing was changed"
+    # A repository's visibility is checked by `register`, which a dry run never
+    # reaches. Saying so here is cheaper than a plan that promises a create
+    # GitHub will refuse.
+    [ "${n_create}" -gt 0 ] && echo "  a '+' line is checked for public visibility only when it is actually registered"
+  fi
+  return "${rc}"
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -173,19 +173,63 @@ _rp_valid_gh_repo() {
   esac
 }
 
-# Load POOL_* for pool $1 into the caller's scope. POOL_WATCH is optional and
-# only set on org pools, so every reader must use "${POOL_WATCH:-}".
+# A runner count. Every caller used to test only '' and non-digits, which let
+# through two values that then failed somewhere else and blamed the wrong
+# thing:
+#
+#   '007' passes a digits-only test, is written to POOL_COUNT verbatim, and
+#   comes back out of _rp_status_json as "count":007 — which Python and Node
+#   both reject, taking any wrapper reading that JSON down with it.
+#
+#   A twenty-digit count also passes, and then `[ "${count}" -ge 1 ]` prints
+#   its own 'integer expression expected' with an internal path in it before
+#   the caller reports some unrelated reason.
+#
+# The upper bound is what keeps `[ -ge ]` off a value libc cannot parse. Four
+# digits is far past anything a single Mac can host, so the bound costs nothing
+# real and the failure it prevents is a raw shell error.
+_rp_valid_count() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;   # empty or not all digits
+    0*)          return 1 ;;   # leading zero, and plain '0' with it
+  esac
+  [ "${#1}" -le 4 ] || return 1
+  return 0
+}
+
+# The one sentence every caller prints when _rp_valid_count says no. Kept here
+# so the pools file and the command line cannot drift into describing the same
+# rule differently.
+_rp_count_rule() { echo "a runner count is a whole number from 1 to 9999, written without a leading zero"; }
+
+# Load POOL_* for pool $1 into the caller's scope. POOL_WATCH is set only on
+# org pools, so every reader still uses "${POOL_WATCH:-}".
+#
+# EVERY POOL_* is cleared first, not just POOL_WATCH. Clearing one of them was
+# enough while nothing loaded more than one pool per process; `apply` reconciles
+# a whole file in one, and a config missing a field then inherited the previous
+# pool's value and got planned against it. A pool silently taking on its
+# neighbour's count, directory or labels is worse than any error.
+#
+# The four fields below are dereferenced without a default all over this tool —
+# POOL_COUNT in arithmetic, POOL_DIR as a path prefix — so a config that
+# survived sourcing but defines none of them is refused here rather than
+# somewhere further on.
+# shellcheck disable=SC2034  # every POOL_* here is read by another lib/ fragment
 _rp_load_pool() {
   local conf; conf="$(_rp_pool_conf "$1")"
   if [ ! -f "${conf}" ]; then
     _rp_err "unknown pool: $1 (see 'runpool pools')"; return 1
   fi
-  # Cleared before sourcing so that `set -u` does not trip on a repo pool,
-  # whose config file has no POOL_WATCH line at all.
-  # shellcheck disable=SC2034  # read by lib/scheduler.sh
-  POOL_WATCH=""
+  POOL_NAME=""; POOL_SCOPE=""; POOL_TARGET=""; POOL_COUNT=""
+  POOL_DIR=""; POOL_LABELS=""; POOL_WATCH=""
   # shellcheck disable=SC1090
-  . "${conf}"
+  . "${conf}" || { _rp_err "pool '$1': could not read ${conf}"; return 1; }
+  if [ -z "${POOL_SCOPE}" ] || [ -z "${POOL_TARGET}" ] || \
+     [ -z "${POOL_COUNT}" ] || [ -z "${POOL_DIR}" ]; then
+    _rp_err "pool '$1': ${conf} is incomplete (needs POOL_SCOPE, POOL_TARGET, POOL_COUNT and POOL_DIR)"
+    return 1
+  fi
 }
 
 # find, not a glob, so an empty pool directory stays silent rather than

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -18,6 +18,7 @@ RUNPOOL_CONFIG="${RUNPOOL_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpool/co
 # invocation at a scratch directory. That matters for anything testing this
 # on a machine that already has a config, the Homebrew test block included.
 _rp_env_BASE="${RUNPOOL_BASE:-}"
+_rp_env_POOLS_FILE="${RUNPOOL_POOLS_FILE:-}"
 _rp_env_LOG_DIR="${RUNPOOL_LOG_DIR:-}"
 _rp_env_LABEL_NS="${RUNPOOL_LABEL_NS:-}"
 _rp_env_IDLE_SECS="${RUNPOOL_IDLE_SECS:-}"
@@ -37,6 +38,7 @@ set -a
 set +a
 
 [ -n "${_rp_env_BASE}" ]        && RUNPOOL_BASE="${_rp_env_BASE}"
+[ -n "${_rp_env_POOLS_FILE}" ]  && RUNPOOL_POOLS_FILE="${_rp_env_POOLS_FILE}"
 [ -n "${_rp_env_LOG_DIR}" ]     && RUNPOOL_LOG_DIR="${_rp_env_LOG_DIR}"
 [ -n "${_rp_env_LABEL_NS}" ]    && RUNPOOL_LABEL_NS="${_rp_env_LABEL_NS}"
 [ -n "${_rp_env_IDLE_SECS}" ]   && RUNPOOL_IDLE_SECS="${_rp_env_IDLE_SECS}"
@@ -44,14 +46,15 @@ set +a
 [ -n "${_rp_env_NOTIFY_CMD}" ]  && RUNPOOL_NOTIFY_CMD="${_rp_env_NOTIFY_CMD}"
 [ -n "${_rp_env_JOB_HOOK}" ]    && RUNPOOL_JOB_HOOK="${_rp_env_JOB_HOOK}"
 [ -n "${_rp_env_TELEMETRY}" ]   && RUNPOOL_TELEMETRY="${_rp_env_TELEMETRY}"
-unset _rp_env_BASE _rp_env_LOG_DIR _rp_env_LABEL_NS _rp_env_IDLE_SECS \
-      _rp_env_LOAD_WARN _rp_env_NOTIFY_CMD _rp_env_JOB_HOOK _rp_env_TELEMETRY
+unset _rp_env_BASE _rp_env_POOLS_FILE _rp_env_LOG_DIR _rp_env_LABEL_NS \
+      _rp_env_IDLE_SECS _rp_env_LOAD_WARN _rp_env_NOTIFY_CMD _rp_env_JOB_HOOK \
+      _rp_env_TELEMETRY
 
 # Restored values need exporting again: the restore above is a plain assignment
 # and happens after 'set -a' was turned off.
 export RUNPOOL_BASE RUNPOOL_LOG_DIR RUNPOOL_LABEL_NS RUNPOOL_IDLE_SECS \
        RUNPOOL_LOAD_WARN RUNPOOL_NOTIFY_CMD RUNPOOL_JOB_HOOK RUNPOOL_TELEMETRY \
-       RUNPOOL_CONFIG
+       RUNPOOL_CONFIG RUNPOOL_POOLS_FILE
 
 # Where runners, pool definitions, launch agents and state live. Never the
 # repository: it holds registration credentials.
@@ -66,6 +69,14 @@ RUNPOOL_ACTIVITY="${RUNPOOL_STATE_DIR}/activity"
 RUNPOOL_PAUSE_FLAG="${RUNPOOL_STATE_DIR}/paused"
 # shellcheck disable=SC2034  # read by lib/scheduler.sh
 RUNPOOL_LAST_CLEAN="${RUNPOOL_STATE_DIR}/last-clean"
+
+# The pools `runpool apply` reconciles to. Beside the config rather than under
+# RUNPOOL_BASE, because it is written by a person and copied between machines,
+# while everything under the base is runtime state this tool owns. Derived from
+# XDG_CONFIG_HOME directly and not from RUNPOOL_CONFIG, so pointing the config
+# at /dev/null to isolate a test does not also lose the pools file.
+# shellcheck disable=SC2034  # read by lib/apply.sh
+RUNPOOL_POOLS_FILE="${RUNPOOL_POOLS_FILE:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpool/pools}"
 
 # Prefix for every launch-agent label this tool owns. Configurable so two
 # installations on one machine cannot collide.
@@ -137,6 +148,29 @@ _rp_valid_pool_name() {
     *[!A-Za-z0-9._-]*) return 1 ;;
   esac
   return 0
+}
+
+# A GitHub owner or repository name, by the same reasoning and the same rule.
+# These matter because `apply` is the first thing to write POOL_TARGET and
+# POOL_WATCH from a file rather than from a command line, and _rp_status_json
+# prints both without escaping on the stated grounds that they are GitHub
+# identifiers. This is what keeps that stated assumption true.
+_rp_valid_gh_name() {
+  case "$1" in
+    ''|.|..)           return 1 ;;
+    *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# OWNER/REPO: exactly one slash, with a valid name either side. The rejecting
+# patterns come first so that '/x', 'x/' and 'a/b/c' never reach the split.
+_rp_valid_gh_repo() {
+  case "$1" in
+    */*/*|/*|*/) return 1 ;;
+    */*)         _rp_valid_gh_name "${1%%/*}" && _rp_valid_gh_name "${1#*/}" ;;
+    *)           return 1 ;;
+  esac
 }
 
 # Load POOL_* for pool $1 into the caller's scope. POOL_WATCH is optional and

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -147,6 +147,22 @@ _rp_write_pool_count() {
     && mv -f "${conf}.tmp" "${conf}"
 }
 
+# The watched repositories an org pool autoscales on. Appended rather than
+# replaced when the line is absent, because `register` writes no POOL_WATCH at
+# all and every pool it created therefore lacks one.
+#
+# '|' as the sed delimiter, since a watch list is full of slashes. Both halves
+# are safe: _rp_valid_gh_repo has already rejected anything containing either.
+_rp_write_pool_watch() {
+  local conf; conf="$(_rp_pool_conf "$1")"
+  if grep -q '^POOL_WATCH=' "${conf}" 2>/dev/null; then
+    sed "s|^POOL_WATCH=.*|POOL_WATCH=\"$2\"|" "${conf}" >| "${conf}.tmp" \
+      && mv -f "${conf}.tmp" "${conf}"
+  else
+    printf 'POOL_WATCH="%s"\n' "$2" >> "${conf}"
+  fi
+}
+
 _rp_set_count() {
   _rp_require gh || return 1
   local name="$1" want="$2"

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -14,27 +14,69 @@ _rp_register() {
   _rp_require curl || return 1
   _rp_require tar  || return 1
 
-  local name="$1"; shift
-  [ -n "${name}" ] || { _rp_err "usage: runpool register <pool> --repo OWNER/REPO|--org ORG [--count N]"; return 1; }
+  local name="${1:-}"; [ $# -gt 0 ] && shift
+  [ -n "${name}" ] || { _rp_err "usage: runpool register <pool> --repo OWNER/REPO|--org ORG [--count N] [--watch OWNER/REPO,...] [--allow-public]"; return 1; }
   _rp_valid_pool_name "${name}" || {
     _rp_err "invalid pool name: '${name}'"
     _rp_err "Letters, digits, dot, underscore and hyphen only: the name becomes a directory, a launch-agent label and a JSON field."
     return 1
   }
 
-  local scope="" target="" count="2" allow_public=0 vis="" pub=""
+  local scope="" target="" count="2" watch="" clean="" tok allow_public=0 vis="" pub=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --repo)         scope="repo"; target="$2"; shift 2 ;;
-      --org)          scope="org";  target="$2"; shift 2 ;;
-      --count)        count="$2";   shift 2 ;;
+      --repo|--org|--count|--watch)
+        # Checked before shifting two, the same way lib/apply.sh checks it.
+        # Without this 'runpool register zz --org' died on a raw '$2: unbound
+        # variable' with an internal line number and no usage message.
+        [ $# -ge 2 ] || { _rp_err "$1 needs a value"; return 1; }
+        case "$1" in
+          --repo)  scope="repo"; target="$2" ;;
+          --org)   scope="org";  target="$2" ;;
+          --count) count="$2" ;;
+          # Repeated --watch accumulates, matching the pools file: one
+          # vocabulary means the same flag given twice means the same thing
+          # in both places.
+          --watch) watch="${watch},$2" ;;
+        esac
+        shift 2
+        ;;
       --allow-public) allow_public=1; shift ;;
       *) _rp_err "unknown flag: $1"; return 1 ;;
     esac
   done
   [ -n "${scope}" ] && [ -n "${target}" ] || { _rp_err "one of --repo OWNER/REPO or --org ORG is required"; return 1; }
-  case "${count}" in ''|*[!0-9]*) _rp_err "--count must be a positive integer"; return 1 ;; esac
-  [ "${count}" -ge 1 ] || { _rp_err "--count must be at least 1"; return 1; }
+
+  # The same validators lib/apply.sh runs over the pools file. They lived in
+  # lib/common.sh with only that one caller, so a target given on the command
+  # line reached the config file unchecked and 'runpool register x --org a"b'
+  # wrote POOL_TARGET="a"b" — a config that then fails to source at all, taking
+  # the pool with it.
+  if [ "${scope}" = "org" ]; then
+    _rp_valid_gh_name "${target}" || { _rp_err "'${target}' is not an organisation name"; return 1; }
+  else
+    _rp_valid_gh_repo "${target}" || { _rp_err "'${target}' is not OWNER/REPO"; return 1; }
+  fi
+  _rp_valid_count "${count}" || { _rp_err "--count: $(_rp_count_rule), got '${count}'"; return 1; }
+
+  # Spaces are dropped so that --watch "a/b, c/d" reads as the pools file
+  # writes it. Entries are rebuilt from what was validated rather than kept as
+  # typed, so ',a/b' cannot be checked as one entry and stored as two.
+  watch="${watch#,}"; watch="${watch// /}"
+  if [ -n "${watch}" ]; then
+    # A repo pool polls its own target and _rp_autoscale never reads POOL_WATCH
+    # for one. Refused rather than ignored: silently doing nothing is how a
+    # pool ends up never waking and nobody knowing why.
+    [ "${scope}" = "org" ] || {
+      _rp_err "--watch applies to org pools only — a repo pool polls ${target} itself"
+      return 1
+    }
+    for tok in $(echo "${watch}" | tr ',' ' '); do
+      _rp_valid_gh_repo "${tok}" || { _rp_err "watched repository '${tok}' is not OWNER/REPO"; return 1; }
+      clean="${clean},${tok}"
+    done
+    watch="${clean#,}"
+  fi
 
   # Whose job the public-repository check is depends on the scope, and the two
   # cases are genuinely different.
@@ -120,7 +162,14 @@ _rp_register() {
     i=$(( i + 1 ))
   done
 
-  cat >| "$(_rp_pool_conf "${name}")" <<CONF
+  # POOL_WATCH is written here, in the same file write as everything else,
+  # rather than added afterwards by whoever called this. An org pool with no
+  # watch list never autoscales, so a create that succeeds and a write that
+  # follows it leaves a window where a crash produces a pool that works, looks
+  # healthy, and silently never wakes — with nothing recording why. One write,
+  # no window. Repo pools get no line at all: they poll their own target.
+  {
+    cat <<CONF
 POOL_NAME="${name}"
 POOL_SCOPE="${scope}"
 POOL_TARGET="${target}"
@@ -128,6 +177,8 @@ POOL_COUNT="${count}"
 POOL_DIR="${dir_base}"
 POOL_LABELS="${labels}"
 CONF
+    if [ -n "${watch}" ]; then printf 'POOL_WATCH="%s"\n' "${watch}"; fi
+  } >| "$(_rp_pool_conf "${name}")"
   _rp_log "pool '${name}' registered: ${count} runner(s) on ${scope} ${target} (stopped)"
   _rp_log "it will come up on its own when a job queues, or now with: runpool up ${name}"
 }
@@ -147,28 +198,40 @@ _rp_write_pool_count() {
     && mv -f "${conf}.tmp" "${conf}"
 }
 
-# The watched repositories an org pool autoscales on. Appended rather than
-# replaced when the line is absent, because `register` writes no POOL_WATCH at
-# all and every pool it created therefore lacks one.
+# The watched repositories an org pool autoscales on. Only `apply`'s change
+# path uses this: a create writes POOL_WATCH inside register's own heredoc, so
+# a pool never exists without the watch list it was asked for.
 #
-# '|' as the sed delimiter, since a watch list is full of slashes. Both halves
-# are safe: _rp_valid_gh_repo has already rejected anything containing either.
+# Rebuilt whole and moved into place, exactly like _rp_write_pool_count, and
+# for a sharper reason than symmetry. This used to append when the line was
+# absent, and against a config whose last line had no newline the append landed
+# on the end of POOL_LABELS:
+#
+#   POOL_LABELS="self-hosted,macOS,ARM64,acme"POOL_WATCH="acme-inc/api"
+#
+# which corrupts POOL_LABELS permanently and leaves POOL_WATCH empty. POOL_LABELS
+# is what `set-count` and `reregister` hand to config.sh, so the runners come
+# back registered under a label set no workflow's runs-on matches, and the pool
+# looks healthy the whole time.
+#
+# awk rather than cat or sed: awk terminates every record with ORS, which is
+# what supplies the newline a file was missing. The value needs no quoting —
+# _rp_valid_gh_repo has already rejected anything but GitHub identifiers and
+# commas.
 _rp_write_pool_watch() {
   local conf; conf="$(_rp_pool_conf "$1")"
-  if grep -q '^POOL_WATCH=' "${conf}" 2>/dev/null; then
-    sed "s|^POOL_WATCH=.*|POOL_WATCH=\"$2\"|" "${conf}" >| "${conf}.tmp" \
-      && mv -f "${conf}.tmp" "${conf}"
-  else
-    printf 'POOL_WATCH="%s"\n' "$2" >> "${conf}"
-  fi
+  awk -v v="$2" '
+    /^POOL_WATCH=/ { print "POOL_WATCH=\"" v "\""; seen = 1; next }
+                   { print }
+    END            { if (!seen) print "POOL_WATCH=\"" v "\"" }
+  ' "${conf}" >| "${conf}.tmp" && mv -f "${conf}.tmp" "${conf}"
 }
 
 _rp_set_count() {
   _rp_require gh || return 1
   local name="$1" want="$2"
   [ -n "${name}" ] && [ -n "${want}" ] || { _rp_err "usage: runpool set-count <pool> <n>"; return 1; }
-  case "${want}" in ''|*[!0-9]*) _rp_err "count must be a positive integer"; return 1 ;; esac
-  [ "${want}" -ge 1 ] || { _rp_err "count must be at least 1"; return 1; }
+  _rp_valid_count "${want}" || { _rp_err "count: $(_rp_count_rule), got '${want}'"; return 1; }
   _rp_load_pool "${name}" || return 1
 
   local have="${POOL_COUNT}"

--- a/runpool.conf.example
+++ b/runpool.conf.example
@@ -16,7 +16,12 @@
 # The pools `runpool apply` reconciles this machine to. Defaults to
 # ~/.config/runpool/pools; see runpool.pools.example. Unlike everything else
 # here it holds no secrets and nothing machine-specific, so it is the one file
-# worth carrying to a second machine.
+# worth carrying to a second machine. `runpool apply --file PATH` overrides it
+# for a single run.
+#
+# Derived from XDG_CONFIG_HOME rather than from this file's own directory, so
+# pointing RUNPOOL_CONFIG at /dev/null does not also lose the pools file. The
+# corollary is that neither RUNPOOL_CONFIG nor RUNPOOL_BASE isolates this one.
 # RUNPOOL_POOLS_FILE="${HOME}/.config/runpool/pools"
 
 # Prefix for every launch-agent label this installation owns. Change it only if

--- a/runpool.conf.example
+++ b/runpool.conf.example
@@ -13,6 +13,12 @@
 # keep it off any synced or shared volume.
 # RUNPOOL_BASE="${HOME}/.local/share/runpool"
 
+# The pools `runpool apply` reconciles this machine to. Defaults to
+# ~/.config/runpool/pools; see runpool.pools.example. Unlike everything else
+# here it holds no secrets and nothing machine-specific, so it is the one file
+# worth carrying to a second machine.
+# RUNPOOL_POOLS_FILE="${HOME}/.config/runpool/pools"
+
 # Prefix for every launch-agent label this installation owns. Change it only if
 # two installations must coexist on one machine.
 # RUNPOOL_LABEL_NS="runpool"

--- a/runpool.pools.example
+++ b/runpool.pools.example
@@ -11,14 +11,26 @@
 # It holds no credentials and nothing machine-specific, so it is safe to keep
 # in a dotfiles repository alongside anything else you carry between machines.
 #
+# Another path can be used instead, either for one run or for good:
+#
+#   runpool apply --file ./pools            one run, this file
+#   RUNPOOL_POOLS_FILE=... runpool apply    one run, from the environment
+#   RUNPOOL_POOLS_FILE in the config file   every run on this machine
+#
 # One pool per line, written exactly as its `register` arguments minus the word
-# `register`. Blank lines and '#' comments are ignored, and a trailing '\'
-# continues onto the next line.
+# `register`:
 #
 #   <name>  --org ORG | --repo OWNER/REPO
 #           [--count N]              runners in the pool; default 2
 #           [--watch OWNER/REPO,...] org pools only, see below
-#           [--allow-public]         only consulted when the pool is created
+#           [--allow-public]         repo pools only, and only consulted when
+#                                    the pool is created
+#
+# Blank lines are ignored. A '#' comments out the line it is on and nothing
+# else. A trailing '\' continues onto the next line, which is what keeps a long
+# --watch list readable — and the line it continues onto has to say something,
+# so a half-uncommented example is an error naming both lines rather than a
+# pool quietly missing half of itself.
 #
 # Reconciliation goes one way. A pool here and not on the machine is created; a
 # count or watch list that differs is changed; a pool on the machine and not
@@ -41,8 +53,14 @@
 # A repo pool needs no --watch. It polls its own target, and giving it one is
 # refused rather than ignored.
 
-# acme  --org acme-inc --count 4 \
-#       --watch acme-inc/api, acme-inc/web, acme-inc/infra
+# acme  --org acme-inc --count 4 --watch acme-inc/api, acme-inc/web
+
+# Long lists are easier to read split across lines. Uncomment every line of it
+# or none of them:
+#
+#   acme  --org acme-inc --count 4 \
+#         --watch acme-inc/api, acme-inc/web \
+#         --watch acme-inc/infra
 
 # ---------------------------------------------------------------------------
 # A personal repository. GitHub has no user-account scope, so a repo outside an

--- a/runpool.pools.example
+++ b/runpool.pools.example
@@ -1,0 +1,60 @@
+# runpool pools — copy to ~/.config/runpool/pools
+#
+# What this machine is meant to have. `runpool apply` reconciles the machine to
+# it; `runpool apply --dry-run` prints what would change and touches nothing.
+#
+# Every example below is commented out, so this file as shipped declares no
+# pools and `runpool apply` on it does nothing. Uncomment and edit. An empty
+# file is valid and means "I am not describing this machine here".
+#
+# This is the file to copy when a second machine should have the same pools.
+# It holds no credentials and nothing machine-specific, so it is safe to keep
+# in a dotfiles repository alongside anything else you carry between machines.
+#
+# One pool per line, written exactly as its `register` arguments minus the word
+# `register`. Blank lines and '#' comments are ignored, and a trailing '\'
+# continues onto the next line.
+#
+#   <name>  --org ORG | --repo OWNER/REPO
+#           [--count N]              runners in the pool; default 2
+#           [--watch OWNER/REPO,...] org pools only, see below
+#           [--allow-public]         only consulted when the pool is created
+#
+# Reconciliation goes one way. A pool here and not on the machine is created; a
+# count or watch list that differs is changed; a pool on the machine and not
+# here is reported and LEFT ALONE. Deleting a pool deregisters its runners with
+# GitHub, so that stays an explicit `runpool remove <pool>`.
+#
+# Changing a pool's scope or target is reported as a conflict rather than
+# applied, because the runners are registered against the old one. Remove the
+# pool and apply again.
+
+# ---------------------------------------------------------------------------
+# An organisation pool. Every repository in the org can use these runners.
+# ---------------------------------------------------------------------------
+# --watch names the repositories to poll for queued work while the pool is
+# down. GitHub reports queued runs per repository and not per organisation, so
+# without it an org pool never wakes on its own and every job waits for someone
+# to run `runpool up`. Only repositories you actually point at the pool belong
+# here: each one costs an API call per tick while the pool is down.
+#
+# A repo pool needs no --watch. It polls its own target, and giving it one is
+# refused rather than ignored.
+
+# acme  --org acme-inc --count 4 \
+#       --watch acme-inc/api, acme-inc/web, acme-inc/infra
+
+# ---------------------------------------------------------------------------
+# A personal repository. GitHub has no user-account scope, so a repo outside an
+# organisation needs its own pool and cannot borrow the one above.
+# ---------------------------------------------------------------------------
+
+# side  --repo me/side-project --count 1
+
+# ---------------------------------------------------------------------------
+# A second machine
+# ---------------------------------------------------------------------------
+# Copy this file across, drop the pools that machine should not have, and run
+# `runpool apply --dry-run` before `runpool apply`. Pool names are per machine,
+# so two machines may use the same names against the same org; the runners
+# register under distinct names because those carry the hostname.

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -37,10 +37,13 @@ Two changes, one in each place.
 
 ```bash
 runpool pools                                        # is there one already?
-runpool register <name> --org ORG --count 4          # org-wide
+runpool register <name> --org ORG --count 4 \
+        --watch OWNER/REPO,OWNER/OTHER               # org-wide
 runpool register <name> --repo OWNER/REPO --count 2  # a single repo
 runpool schedule install                             # once per machine
 ```
+
+**An org pool needs `--watch` or it never autoscales.** See *`--watch` is org-only and matters* below. A repo pool polls its own target and refuses the flag.
 
 **Adding several pools, or setting up a second machine?** Describe them in a file and reconcile to it instead — see *Declaring a machine's pools* below.
 
@@ -65,6 +68,10 @@ acme  --org acme-inc --count 4 \
 side  --repo me/side-project --count 1
 ```
 
+**Another path**, in order of precedence: `runpool apply --file PATH` for one run, `RUNPOOL_POOLS_FILE` in the environment, `RUNPOOL_POOLS_FILE` in `~/.config/runpool/config`. Use `--file` when reading or checking a file that is not the machine's own.
+
+**A `#` comments out the line it is on and nothing else.** A trailing `\` continues onto the next line, and that line has to say something — so a pool commented out across several lines is uncommented entirely or not at all.
+
 ```bash
 runpool apply --dry-run    # always this first
 runpool apply
@@ -76,12 +83,15 @@ Read the plan by its first character: `+` create, `~` change, `=` unchanged, `?`
 
 - **`apply` never deletes.** A pool that is on the machine and not in the file is reported and left alone. If the user wants it gone, that is `runpool remove <pool>`, explicitly.
 - **`!` means the scope or target differs** from what the runners are registered against. `apply` will not fix that; remove the pool and apply again. Say so rather than working around it.
-- **`apply` exits non-zero on a conflict or a parse error**, and names the offending line by number.
+- **`apply` exits non-zero on a conflict or a parse error**, and names the offending line by number. It also refuses a pools file it cannot read, rather than reading it as empty and reporting every real pool as `?`.
+- **A real run prints the whole plan first**, then acts under an `applying:` heading. Read the plan, not the interleaving.
 - **A public repository is still refused**, by `register`, at the moment the pool is actually created. A dry run does not reach that check, so a `+` line is not a promise the create will succeed.
 
 **Prefer this over a sequence of `register` commands whenever there is more than one pool, or more than one machine.** The file is the thing you copy; a remembered sequence of commands is not. `register` is still right for adding a single pool to a machine that has no such file.
 
-**`--watch` is org-only and matters.** GitHub reports queued runs per repository, not per organisation, so an org pool with nothing watched never autoscales and every job waits for a manual `runpool up`. `register` cannot set it at all ([#19](https://github.com/aicayzer/runpool/issues/19)), which is a reason to reach for `apply` for org pools specifically. On a repo pool it is refused, because the pool already polls its own target.
+**`--watch` is org-only and matters.** GitHub reports queued runs per repository, not per organisation, so an org pool with nothing watched never autoscales and every job waits for a manual `runpool up`. Both `register` and the pools file take it, repeated flags accumulate, and both refuse it on a repo pool, because such a pool already polls its own target.
+
+**`--allow-public` is repo-only**, for the mirror-image reason: at organisation scope the control is GitHub's own `allows_public_repositories` on the runner group, so the flag would do nothing. Both routes refuse it there rather than accepting it silently. It is consulted only when a pool is created, so adding or removing it on an existing pool is not drift and `apply` correctly reports `=`.
 
 ## Which scope
 
@@ -118,7 +128,7 @@ runpool status
 - **`running N/N` but `github 0/N`** — the runners started but are not reaching GitHub. Same fix.
 - **`GLOBAL: paused`** — someone hit the kill switch. `runpool resume`.
 - **`running 0/N` and the job is genuinely queued** — the tick brings a pool up within about a minute. Wait one minute before intervening. `runpool up <pool>` forces it.
-- **`running 0/N` on an *org* pool that never comes up on its own** — check the pool's `watch` array in `status --json`. If it is empty, autoscale has nothing to poll, because GitHub reports queued runs per repository rather than per organisation. Add the repository to the pool's line in `~/.config/runpool/pools` and `runpool apply`.
+- **`running 0/N` on an *org* pool that never comes up on its own** — check the pool's `watch` array in `status --json`. If it is empty, autoscale has nothing to poll, because GitHub reports queued runs per repository rather than per organisation. Add the repository to the pool's line in `~/.config/runpool/pools` and `runpool apply`, or `runpool register` it with `--watch` in the first place.
 - **Everything looks right but the job still waits** — check routing rather than capacity. The workflow's `runs-on` may not resolve to `self-hosted`, or its labels may not match the pool's.
 
 ```bash

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -42,6 +42,8 @@ runpool register <name> --repo OWNER/REPO --count 2  # a single repo
 runpool schedule install                             # once per machine
 ```
 
+**Adding several pools, or setting up a second machine?** Describe them in a file and reconcile to it instead — see *Declaring a machine's pools* below.
+
 **2. Routing.** In the workflow, route the job:
 
 ```yaml
@@ -51,6 +53,35 @@ runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 Then set the repository variable `CI_RUNNER` to `self-hosted`. The fallback keeps the workflow working for anyone without the pool, and the variable means switching back to hosted is one setting rather than a commit.
 
 **Never add an automatic fallback to hosted runners.** On macOS that silently costs ten times as much, and if the hosted allowance is exhausted it fails anyway. A job waiting for a pool that is down is the correct behaviour.
+
+## Declaring a machine's pools
+
+`~/.config/runpool/pools` describes what the machine should have, one pool per line, written as its `register` arguments minus the word `register`. `runpool apply` reconciles the machine to it.
+
+```
+acme  --org acme-inc --count 4 \
+      --watch acme-inc/api, acme-inc/web
+
+side  --repo me/side-project --count 1
+```
+
+```bash
+runpool apply --dry-run    # always this first
+runpool apply
+```
+
+**Always run `--dry-run` and show the user the plan before applying.** Applying registers runners with GitHub and can resize a pool downward, which deregisters real runners.
+
+Read the plan by its first character: `+` create, `~` change, `=` unchanged, `?` on the machine but not in the file, `!` conflict.
+
+- **`apply` never deletes.** A pool that is on the machine and not in the file is reported and left alone. If the user wants it gone, that is `runpool remove <pool>`, explicitly.
+- **`!` means the scope or target differs** from what the runners are registered against. `apply` will not fix that; remove the pool and apply again. Say so rather than working around it.
+- **`apply` exits non-zero on a conflict or a parse error**, and names the offending line by number.
+- **A public repository is still refused**, by `register`, at the moment the pool is actually created. A dry run does not reach that check, so a `+` line is not a promise the create will succeed.
+
+**Prefer this over a sequence of `register` commands whenever there is more than one pool, or more than one machine.** The file is the thing you copy; a remembered sequence of commands is not. `register` is still right for adding a single pool to a machine that has no such file.
+
+**`--watch` is org-only and matters.** GitHub reports queued runs per repository, not per organisation, so an org pool with nothing watched never autoscales and every job waits for a manual `runpool up`. `register` cannot set it at all ([#19](https://github.com/aicayzer/runpool/issues/19)), which is a reason to reach for `apply` for org pools specifically. On a repo pool it is refused, because the pool already polls its own target.
 
 ## Which scope
 
@@ -87,6 +118,7 @@ runpool status
 - **`running N/N` but `github 0/N`** — the runners started but are not reaching GitHub. Same fix.
 - **`GLOBAL: paused`** — someone hit the kill switch. `runpool resume`.
 - **`running 0/N` and the job is genuinely queued** — the tick brings a pool up within about a minute. Wait one minute before intervening. `runpool up <pool>` forces it.
+- **`running 0/N` on an *org* pool that never comes up on its own** — check the pool's `watch` array in `status --json`. If it is empty, autoscale has nothing to poll, because GitHub reports queued runs per repository rather than per organisation. Add the repository to the pool's line in `~/.config/runpool/pools` and `runpool apply`.
 - **Everything looks right but the job still waits** — check routing rather than capacity. The workflow's `runs-on` may not resolve to `self-hosted`, or its labels may not match the pool's.
 
 ```bash


### PR DESCRIPTION
Closes #18, #19, #21, #22, #23, #24, #25, #26, #27, #28, #31, #32.

Pools could only be created imperatively, so a machine's setup existed only as a sequence of `register` commands somebody remembered running. This adds a file describing the desired pools and `runpool apply` to reconcile to it. `register` is unchanged.

## The file

`~/.config/runpool/pools`, one pool per line, written as that pool's `register` arguments minus the word `register` — one vocabulary to learn rather than two. Blank lines and `#` comments are ignored, and a trailing `\` continues onto the next line, which is what keeps a long `--watch` list readable.

```
acme  --org acme-inc --count 4 \
      --watch acme-inc/api, acme-inc/web

side  --repo me/side-project --count 1
```

Parsed by hand, not sourced: stock bash 3.2, no new dependencies, and a file meant to be copied between machines should not also be a shell script. Hand parsing is also what lets a bad line name itself by number.

## What apply does

```
  ~ acme         org  acme-inc          count 2 -> 4; watch (none) -> acme-inc/api,acme-inc/web
  = side         repo me/side-project   up to date (1 runner(s))
  ! solo         org  wrong-org         registered here, but the file says org acme-inc — 'runpool remove solo' first
  + fresh        org  acme-inc          create with 2 runner(s), watching acme-inc/new
  ? old          repo me/retired        not in the file — left alone ('runpool remove old' to delete it)
```

**Reconciliation goes one way.** Create what is missing, change what differs, and *report* what is on the machine and not in the file. Deleting a pool deregisters runners with GitHub, and a missing line is far too quiet a way to ask for that, so `remove` stays explicit. A changed scope or target is a conflict rather than an action, because the runners are registered against the old one; `apply` exits non-zero and says to `remove` first.

## `POOL_WATCH` gets its first writer

`lib/scheduler.sh` has always read `POOL_WATCH` in both `_rp_autoscale` and `_rp_status_json`, and nothing ever wrote it — `register` builds the pool conf from a fixed heredoc with no such line and takes no `--watch`. So **an org pool registered by the documented route never autoscales**, and `status` reports it as perfectly healthy. `apply` sets it, validating each entry as `OWNER/REPO` first, which is also what keeps `_rp_status_json`'s stated assumption true: it prints watched repos into hand-assembled JSON without escaping, on the grounds that they are GitHub identifiers, and until now nothing enforced that. **`register` takes `--watch` too, and writes it in the same heredoc as the rest of the pool** (#19). It was going to be a follow-up, but it is entangled with the review fixes below and doing it here *closes* the atomicity window rather than narrowing it: `apply` used to append the watch list after a successful create, so a death between the two left a working pool that never autoscales with nothing recording why. One file write, no window. `apply`'s create path now passes `--watch` through and the post-write is gone; `_rp_write_pool_watch` stays for the change path only, because `register` is create-only and re-runs `config.sh` against every runner — routing an edit to one line of text through it would re-register real runners.

## Three traps, handled and commented where they sit

- **Word splitting is the tokeniser**, so the parser body is a subshell with `set -f`. Verified: a line reading `a --org *` reports `'*' is not an organisation name` rather than expanding against the working directory.
- **Records are separated by `|`, not a tab.** Tab is IFS whitespace, so a run of them collapses and the empty `watch` field in the middle of a record silently disappears when `read` splits it back out. I hit this in a probe before writing the parser; every field is validated to characters that cannot include `|`.
- **Records reach the reconcile loop on fd 3.** `register` shells out to the runner's `config.sh` and to `gh`, and anything in the loop body reading stdin would eat the rest of the plan.

`shift 2` is also guarded by an explicit `[ $# -ge 2 ]`, because with one argument left it fails *without shifting*, which turns a truncated line into an infinite loop rather than an error.

## Tested

Stock `/bin/bash` 3.2.57 throughout, against a scratch `RUNPOOL_BASE` with `RUNPOOL_LOG_DIR` also redirected — the log otherwise defaults into a real installation. Both CI checks pass locally: `/bin/bash -n` over every file, and shellcheck `--severity=warning` via the Docker image in CONTRIBUTING.md, clean.

- **Parser, 15 rejection cases, one file each**: invalid pool name, duplicate pool, both scopes, no scope, count of zero, non-numeric count, org name containing a slash, repo target with no slash, repo target with two, `--watch` on a repo pool, watch entry that is not `OWNER/REPO`, flag with no value, unknown field, trailing `\` at EOF, and a file declaring nothing. Each names the file and line and exits 1 — except the last, which is a valid state and reports without failing.
- **Reconcile, against hand-made pool configs**: every plan symbol exercised. Verified the dry run recorded **zero** calls and left every conf byte-identical; that the real run called exactly `set-count acme 4`, `register fresh --org acme-inc --count 2`, `register pub --repo me/oss --count 1 --allow-public`; that the conflicting pool was untouched; that the unmanaged pool still existed afterwards; and that **a second run is a true no-op** — 0 calls, everything `=`.
- **Round trip**: `POOL_WATCH` written by `apply` is read back by `_rp_load_pool`, expands to the right `/repos/…/actions/runs` polls in autoscale's loop, and appears correctly as the `watch` array in `status --json --local`.
- **Config precedence, the trap AGENTS.md warns about**: `RUNPOOL_POOLS_FILE` set only in the config file is used; the environment overrides it; `--file` overrides both. Added in all four places in the `lib/common.sh` block (snapshot, restore, `unset`, `export`).
- **`install.sh`** into a scratch `PREFIX` and `XDG_CONFIG_HOME`: deploys the example, keeps an edited one on a second run, and the symlinked binary resolves `lib/apply.sh` correctly.

**Two real defects surfaced during that testing**, both fixed in this branch: the shipped example originally had live pool lines, so a fresh install left `runpool apply` ready to register two fictional pools; and an empty record set still fed one blank line through `printf`, which read back as a nameless pool and planned a create for it.

## Not tested

**`register` and `set-count` were replaced by recorders**, so what is verified is the arguments `apply` builds and the state it writes, not the registration itself. Actually creating a pool downloads a runner and needs `gh` with admin on a real target, and there was no throwaway org to point at. The paths that talk to GitHub are unchanged by this PR, but `apply`'s create path has never run end to end.

Two consequences worth knowing rather than assuming:

- **A `+` line is a plan, not a promise.** The public-repository refusal lives in `register`, which a dry run never reaches, so a create can still be refused at apply time. `--dry-run` says so in its output.
- **`set-count` refuses while a job is in flight.** `apply` handles that as a per-pool failure and carries on with the rest of the plan, then exits non-zero — but that specific interaction was exercised through the recorder, not against a busy pool.

## Review fixes

A review of the branch found ten defects. All ten are fixed here, each reproduced first and shown fixed after; the eight that warranted their own record are filed as issues and closed by the commit that fixes them.

**In severity order:**

1. **A comment ending in `\` swallowed the pool it was joined to** (#21). Continuation was detected before comment stripping, so `#` ate whatever it continued onto — at exit 0, with a silently different pool. **The shipped template taught it:** uncommenting only the first line of its two-line example gave a pool with *no watch list*, which is the never-autoscales state this feature exists to prevent; uncommenting only the second gave "declares no pools". Comments are now stripped per **physical** line, so `#` ends at the line it is on — which is what it means everywhere else, and which costs nothing worth having, since a trailing comment still works on any physical line including the last of a continuation. A continuation landing on a blank or comment line is a parse error naming both lines, and a line starting with a flag says so rather than reporting an invalid pool name. The template's examples are one line each, so half-uncommenting one cannot happen.
2. **An unreadable pools file reported the inverse of the truth** (#22): every real pool as `? not in the file`, exit 0. Presence, directory and readability are three separate messages now, tested with `-e`/`-r` rather than `-f` — which also resolves the asymmetry where `RUNPOOL_POOLS_FILE=/dev/null` failed while `/dev/null` is the recommended isolation idiom for `RUNPOOL_CONFIG`.
3. **`--count 007` was accepted and made `status --json` invalid JSON**, and an oversized count leaked `[: integer expression expected` before reporting the wrong reason (#23). One shared `_rp_valid_count` in `lib/common.sh` now serves the pools file, `register` and `set-count`, with one sentence describing the rule.
4. **`_rp_write_pool_watch` appended without a newline guard** (#24), gluing `POOL_WATCH` onto the end of `POOL_LABELS` and corrupting the labels *permanently* while leaving the watch list empty — and `POOL_LABELS` is what `set-count` and `reregister` hand to `config.sh`. Rebuilt whole and moved into place, like its sibling.
5. **`_rp_load_pool` cleared only `POOL_WATCH`** (#25), so a config missing a field inherited the previous pool's value and `apply` planned against it. All of them are cleared, and a config defining none of the four load-bearing fields is refused there rather than failing somewhere further on.
6. **`--allow-public` was silently a no-op on org pools** (#26). Refused now, exactly as `--watch` is refused on a repo pool and for the same stated reason. It is still not compared as drift, deliberately — see *Deliberately not changed*.
7. Covered by #23.
8. **Malformed watch lists passed validation and were stored verbatim** (#23): splitting on commas dropped empty entries *before* the check, so `,acme-inc/api` was approved as one entry and written as typed. Rebuilt from the entries that were actually validated.
9. **`n_absent` was counted before the config was known to load** (#27), so the summary could claim two pools above one `?` line — and the failure was reflected in neither the count nor the exit status.
10. **A non-dry `apply` interleaved its plan with its execution** (#27). Split into a decide-and-print pass and an act pass: the whole plan prints first, actions run under an `applying:` heading, the summary comes last and counts what actually happened. The README's sample now shows that ordering.

**Cross-cutting** (#28): `register` had no `[ $# -ge 2 ]` guard, so `runpool register zz --org` died on a raw `$2: unbound variable`; and `_rp_valid_gh_name`/`_rp_valid_gh_repo` had only one caller, so `register x --org 'a"b'` wrote `POOL_TARGET="a"b"` — a config that then fails to source, taking the pool with it. Both fixed.

## Issues filed

Ten review findings, twelve issues, and the grouping is deliberate rather than mechanical:

- **#21** comment/continuation, including the shipped template that teaches it. **#22** unreadable pools file. **#24** the `POOL_WATCH` append. **#25** `POOL_*` leaking between pools. **#26** `--allow-public` at org scope. **#28** `register`'s argv guard and unvalidated target.
- **#23** groups findings 3, 7 and 8 — leading zeros, oversized counts and malformed watch lists are one defect wearing three hats: the parser validating one value and storing another. One commit fixes all three.
- **#27** groups findings 9 and 10 — both are `apply` misreporting itself, and the plan/execute split fixes the miscount as a side effect of fixing the interleaving.
- **#29** and **#30** are the two defects this PR had already fixed without filing: the shipped example's live pool lines, and the blank record that planned a nameless create. Filed and closed against 9b5f66d, per `AGENTS.md`.
- **#31** and **#32** are documentation. #31 is not cosmetic: `CONTRIBUTING.md` told contributors to isolate `lib/apply.sh` testing with a scratch `RUNPOOL_BASE`, and **`RUNPOOL_BASE` does not move the pools file** — verified. Anyone following it and dropping `--dry-run` would have registered every pool from their real file into a scratch base, against real GitHub targets. #32 is `--file` and `RUNPOOL_POOLS_FILE` existing only in `--help`, plus AGENTS.md's "three-way split" above a five-file listing.

## Deliberately not changed

- **`--allow-public` is still not compared as drift.** It is not pool state and is recorded nowhere: it is permission to perform a create, consulted once by `register` and meaningless afterwards. Adding or removing it on an existing pool changes nothing about the pool, so `=` is the truthful answer. The code now says so where someone would otherwise read it as an oversight, and the skill says so for users. Making it drift would mean inventing a `POOL_ALLOW_PUBLIC` with no action attached to it.
- **`_rp_write_pool_watch` was not folded into `register`.** `register` is create-only and re-runs `config.sh` against every runner in the pool, so routing a watch-list edit through it would deregister and re-register real runners to change one line of text.
- **The org/repo asymmetry in the public-repository check** is untouched, per `AGENTS.md` and `SECURITY.md`. Refusing `--allow-public` at org scope is not evening the two branches up; it is refusing a flag that does nothing there, and the message names GitHub's `allows_public_repositories` as the equivalent.

## Verified

Everything below under stock `/bin/bash` 3.2.57 on macOS, against a scratch `RUNPOOL_BASE`, `RUNPOOL_LOG_DIR`, `RUNPOOL_CONFIG=/dev/null` **and** `RUNPOOL_POOLS_FILE` — the last of which is the point of #31.

**Each finding was reproduced on the branch before it was fixed**, and the same case re-run after. A 29-case sweep covers: all four comment/continuation shapes including the two the template taught and the two that must still work; unreadable, missing, directory and `/dev/null` pools files; six rejected counts and two accepted ones, with an explicit assertion that no raw shell error reaches the user; watch-list normalisation at both ends and in the middle; `--allow-public` refused at org scope and accepted at repo scope; watch drift detected, whitespace-only difference *not* detected as drift, scope change reported as a conflict with a non-zero exit; `--dry-run` leaving every pool config byte-identical and creating nothing; and `--help`, `pools` and `status --json --local` still working, the last parsed by Python.

**Issue #19 end to end**, with `gh`, `tar` and the plist writer stubbed so nothing reaches GitHub: repeated `--watch` accumulates, `--watch "a/b, c/d"` reads the way the pools file writes it, empty entries are dropped, a repo pool gets no `POOL_WATCH` line at all, the value round-trips through `_rp_load_pool` into the right `/repos/…/actions/runs` polls, and `status --json` parses with the watch array intact.

**`apply` against recorder stand-ins** for `register` and `set-count`: the plan prints in full before the first call, `register` is called with `--watch` and no post-write follows it, and a second run is a true no-op — 0 calls, everything `=`.

Both CI checks pass locally and on the PR: `/bin/bash -n` over every file under 3.2.57, and shellcheck `--severity=warning` via the Docker image in `CONTRIBUTING.md`, clean.

## Still not tested

Unchanged from the original list, and worth restating because #19 widens it slightly: **`register` has still never run end to end against real GitHub.** The `--watch` parsing, validation and conf writing are verified with the network stubbed, but the surrounding create — tarball fetch, registration token, `config.sh` — needs `gh` with admin on a real target and there is no throwaway org to point at. The paths that talk to GitHub are unchanged by this PR.

`_rp_set_count` refusing mid-job is still exercised through a recorder rather than against a busy pool.

## Docs

README gets a section and a command-table row; the skill gets a section on declaring pools, a rule to always dry-run first, and a new entry in the queued-job diagnosis list for the empty-watch case. Two stale claims in AGENTS.md are corrected: "There is no dry-run", which `apply --dry-run` now contradicts, and "add it to both lists" for a new setting, which is four places, not two. The layout block was also missing `lib/stats.sh`.

