### PR TITLE
fix(clean): sweep abandoned Foundation temp directories

### DIFF
--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -504,7 +504,7 @@ _rp_clean() {
   # Every local declared once, at the top. Re-running 'local' for an existing
   # local inside a loop makes some shells print it as a typeset assignment,
   # which once leaked stray lines into the nightly log.
-  local only="${1:-}" p freed_kb=0 sz rd wd dd td live keep vols nvols
+  local only="${1:-}" p freed_kb=0 sz rd wd dd td live keep vols nvols ntmp utmp
   for p in $(_rp_pool_names); do
     [ -n "${only}" ] && [ "${only}" != "${p}" ] && continue
     _rp_load_pool "${p}" || continue
@@ -588,6 +588,39 @@ _rp_clean() {
       nvols=$(printf '%s\n' "${vols}" | wc -l | tr -d ' ')
       printf '%s\n' "${vols}" | xargs docker volume rm >/dev/null 2>&1 || true
       _rp_log "clean: pruned ${nvols} anonymous dangling docker volume(s)"
+    fi
+  fi
+
+  # Foundation item-replacement directories in the per-user temp root.
+  #
+  # Opening a SwiftData store on a file URL makes Foundation create one of
+  # these and never remove it: roughly six per run of a Swift test suite that
+  # touches a file-backed container. They accumulate without bound, and macOS
+  # reports that path as "System Data", so nothing an operator looks at shows
+  # them growing. One reading passed ten thousand entries.
+  #
+  # Two things make this safe to sweep here and unsafe to sweep casually.
+  # The path is shared with every process the user runs, unlike the per-runner
+  # temp above, so only entries matching Foundation's own name are touched and
+  # only ones untouched for days. These directories exist for the moment of an
+  # atomic file replacement; one that has sat for three days was abandoned by
+  # a process that is no longer running. Anything newer is left alone, which
+  # also means a job running right now cannot be interfered with.
+  #
+  # Not restricted to runner activity on purpose: the same leak comes from
+  # local development on this machine, and it is the same directory either way.
+  ntmp=0
+  utmp="$(getconf DARWIN_USER_TEMP_DIR 2>/dev/null)"
+  if [ -n "${utmp}" ] && [ -d "${utmp}" ]; then
+    sz=$(du -sk "${utmp}" 2>/dev/null | awk '{print $1}')
+    while IFS= read -r td; do
+      [ -d "${td}" ] || continue
+      rm -rf "${td}" 2>/dev/null && ntmp=$(( ntmp + 1 ))
+    done < <(find "${utmp%/}" -mindepth 1 -maxdepth 1 -type d \
+               -name 'TemporaryDirectory.*' -mtime +2 2>/dev/null)
+    if [ "${ntmp}" -gt 0 ]; then
+      freed_kb=$(( freed_kb + sz - $(du -sk "${utmp}" 2>/dev/null | awk '{print $1}') ))
+      _rp_log "clean: swept ${ntmp} abandoned Foundation temp dir(s)"
     fi
   fi
 


### PR DESCRIPTION
Closes #37.

Opening a SwiftData store on a file URL makes Foundation create an item-replacement directory in the per-user temp root and never remove it — roughly six per run of a Swift test suite that touches a file-backed container. They accumulate without bound, and macOS reports that path as "System Data", so nothing an operator looks at shows them growing.

The existing sweep never sees them. Runner temp is redirected per runner and wiped wholesale, which is safe precisely because nothing else writes there; these land in the shared per-user root instead, from CI and local development alike.

So this sits with the dangling-Docker-volume prune, which is already machine-wide rather than per-runner.

## What makes it safe on a shared path

- Only entries matching Foundation's own name. A wildcard sweep of that directory would delete another process's working directory.
- Only entries untouched for three days. These exist for the moment of an atomic file replacement, so one that has sat that long was abandoned by a process no longer running, and anything a live job created is far too recent to match.

Three days rather than something tighter is deliberate: it bounds the growth, which is what the defect is, without betting that nothing on a shared machine holds one open for a while.

## Verified

Measured on the development machine: 711 entries present, 18 older than three days, 525 recent ones untouched, and nothing outside the `TemporaryDirectory.*` pattern matched.

The block itself was exercised against a sandbox containing two old Foundation directories, one recent one, and one old directory that is *not* Foundation's. It removed the two, kept the recent one, and kept the one that was not ours — which is the property that matters on a shared path.

`bash -n` clean. `runpool clean` was not run against the live pools, since it prunes real runner state and CI was active.