### PR TITLE
feat: add native storage and pool pause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: shellcheck
         run: |
           sudo apt-get update -qq && sudo apt-get install -y shellcheck
-          shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh install.sh
+          shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
 
   bash32:
     # Stock macOS ships bash 3.2, so the tool has to parse under it. macOS
@@ -33,6 +33,8 @@ jobs:
       - name: parse under stock bash
         run: |
           /bin/bash --version | head -1
-          for f in bin/runpool lib/*.sh contrib/*.sh install.sh; do
+          for f in bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh; do
             /bin/bash -n "$f" && echo "ok  $f"
           done
+      - name: storage migration
+        run: tests/storage-migration.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
 Most changes need runners, which means a GitHub account and a Mac. Two things make that less painful:
 
 - **`contrib/demo-status.sh`** answers `status` with invented pools, so anything consuming the JSON can be developed with no runners at all.
-- **`RUNPOOL_BASE`** points RunPool at a scratch directory, so you can register throwaway pools without touching a real setup. Environment beats config, deliberately, so a single invocation can be isolated. Set `RUNPOOL_LOG_DIR` alongside it: the log defaults to `~/Library/Logs/runpool` and a test will otherwise write into a real installation's log.
+- **`RUNPOOL_BASE`** points RunPool at a scratch directory, so you can register throwaway pools without touching a real setup. Environment beats config, deliberately, so a single invocation can be isolated. Set `RUNPOOL_CACHE_DIR` and `RUNPOOL_LOG_DIR` alongside it: otherwise a test writes caches and logs into a real installation's macOS storage roots.
 - **`RUNPOOL_POOLS_FILE`, or `apply --file PATH`, as well.** `RUNPOOL_BASE` does **not** move the pools file: that is derived from `XDG_CONFIG_HOME`, deliberately, so that isolating the config does not lose it. Isolate the base and forget this one and `runpool apply` reads your **real** pools file and tries to register every pool in it into the scratch base — with real registrations against real GitHub targets.
 - **`runpool apply --dry-run`** calls nothing and changes nothing, so all of `lib/apply.sh` can be exercised against hand-written pool config files with no GitHub account.
 
@@ -46,6 +46,7 @@ Which makes the whole isolated invocation:
 
 ```bash
 RUNPOOL_BASE=/tmp/rp-test \
+RUNPOOL_CACHE_DIR=/tmp/rp-test/cache \
 RUNPOOL_LOG_DIR=/tmp/rp-test/logs \
 RUNPOOL_CONFIG=/dev/null \
 RUNPOOL_POOLS_FILE=/tmp/rp-test/pools \

--- a/README.md
+++ b/README.md
@@ -57,17 +57,18 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | `set-count <pool> N` | Change a pool's runner count |
 | `apply [--dry-run] [--file PATH]` | Reconcile the machine to a file describing its pools |
 | `up` / `down <pool>` | Bring a pool online, or stand it down |
-| `status [--json]` | Local state alongside what GitHub actually sees |
+| `status [--json] [--local]` | Local state alongside what GitHub actually sees |
 | `doctor` | Why is nothing picking this up. Reports; changes nothing |
 | `pools` | List registered pools |
 | `reregister <pool>` | Recreate GitHub registrations, keeping the local install |
 | `remove <pool>` | Deregister and delete a pool |
 | `clean [pool]` | Prune work directories, temp, diagnostics, old binaries, caches |
 | `stats [--queue]` | What jobs actually cost, from recorded telemetry. `--queue` adds the wait before each job started |
-| `pause` / `resume` | Global kill switch |
+| `pause [pool]` / `resume [pool]` | Global kill switch, or persistent per-pool pause |
 | `schedule install\|remove` | The background agents that drive everything above |
+| `migrate-storage [--dry-run]` | Move a legacy installation into macOS storage |
 
-**`status --json --local` skips the GitHub query**, reporting those fields as `null`. Anything refreshing on a timer should use it: one API call per pool per minute is thousands a day, and it makes a passive readout fail whenever the network does.
+**`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`: one API call per pool per minute is thousands a day, and it makes a passive readout fail whenever the network does.
 
 **`doctor` answers "why is nothing picking this up" in one command.** It checks `gh` and its authentication, that GitHub still has the registrations, that the launch agents exist — including the tick agent, which nothing else looks at and without which no pool autoscales at all — and then disk headroom, config permissions and the organisation's runner-group setting. Each failure comes with what to do about it, and it exits non-zero when something is actually wrong. It reports and repairs nothing, so it is safe to run at any moment, including mid-job.
 
@@ -109,6 +110,33 @@ A real run prints that same plan in full first, then acts on it under an `applyi
 The file holds no credentials and nothing machine-specific, so **a second machine gets the same pools by getting the same file.** That is the point of it: `register` does not become wrong, it just stops being the thing you copy.
 
 **`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. `register` takes it too, so a single pool created by hand is no worse off than one from the file; on a repo pool both refuse it, because such a pool already polls its own target.
+
+## Storage and migration
+
+**Required state lives in `~/Library/Application Support/runpool`.** That includes runner installations and credentials, pool definitions, pause state, generated launch agents and telemetry. **Regenerable data lives in `~/Library/Caches/runpool`**: job work trees, checked-out repositories, downloaded actions and tools, package stores, temp directories and runner downloads. Logs remain in `~/Library/Logs/runpool`; the config and pools file remain under `~/.config/runpool`.
+
+`RUNPOOL_BASE`, `RUNPOOL_CACHE_DIR` and `RUNPOOL_LOG_DIR` can override those roots, with the usual precedence: environment, config file, then default. Existing `RUNPOOL_BASE` installations remain active until migrated, so upgrading never silently strands registrations.
+
+Preview a legacy migration first:
+
+```bash
+runpool migrate-storage --dry-run
+runpool migrate-storage
+runpool status --local
+runpool doctor
+```
+
+Migration refuses while a job is running, stops only idle runners, copies runner state into Application Support, moves regenerable per-runner data into Caches, rewrites each runner's absolute work folder and regenerates launch agents. It retains the legacy tree until you have verified the new installation. Remove it only afterwards. For a custom legacy `RUNPOOL_BASE`, use the exact `--from` and `--to` command printed by migration:
+
+```bash
+runpool migrate-storage --remove-legacy
+# Or, for a custom legacy root:
+runpool migrate-storage --from /old/runpool --to "$HOME/Library/Application Support/runpool" --remove-legacy
+```
+
+## Pausing pools
+
+**`runpool pause` and `runpool resume` remain the global controls.** Global pause stops every runner immediately and disables autoscaling. **`runpool pause <pool>` is different:** it safely stands down one idle pool and persists that pool's pause state. A paused pool remains registered, is skipped by autoscaling, and refuses `runpool up <pool>` until `runpool resume <pool>` is run. `down <pool>` remains a temporary stand-down and does not pause the pool.
 
 ## Raycast extension
 

--- a/bin/runpool
+++ b/bin/runpool
@@ -45,54 +45,119 @@ export RUNPOOL_SELF
 . "${RUNPOOL_ROOT}/lib/stats.sh"
 
 _rp_help() {
-  cat <<'HELP'
-runpool — on-demand self-hosted GitHub Actions runner pools for macOS
+  local command="${1:-}"
+  case "${command}" in
+    "")
+      cat <<'HELP'
+Usage: runpool <command>
 
-  register <pool> --repo OWNER/REPO|--org ORG [--count N]
-                  [--watch OWNER/REPO,...] [--allow-public]
-                           create a pool and configure its runners (left stopped)
-                           --watch is org pools only: the repositories polled
-                           for queued work, without which one never autoscales
-                           a public repo is refused; --allow-public overrides it
-                           (repo scope only)
-  set-count <pool> N       change a pool's runner count after registration
-  apply [--dry-run] [--file PATH]
-                           reconcile this machine to a file describing its
-                           pools: create what is missing, resize what differs,
-                           report what is not in the file. Never deletes.
-                           --dry-run prints the plan and changes nothing
-  up|down <pool>           bring a pool online / stand it down
-  up-all|down-all          every pool
-  status [--json] [--local]
-                           local state alongside what GitHub actually sees;
-                           --local skips the GitHub query entirely
-  doctor                   why is nothing picking this up: gh, registrations,
-                           launch agents, disk, permissions. Reports and
-                           changes nothing; exits non-zero if something is wrong
-  pools                    list registered pools
-  stats [--queue]          what recorded jobs cost, to size the pool with data
-                           --queue adds the wait before a runner picked each
-                           job up, joining the records to GitHub: one API call
-                           per run, so it is not part of plain stats
-  reregister <pool>        recreate GitHub registrations, keep the local install
-  remove <pool>            deregister and delete a pool
+Manage on-demand self-hosted GitHub Actions runner pools on macOS.
 
-  tick                     autoscale, idle-down, contention and health checks
-  autoscale|sweep          bring pools up on queued work / stand idle ones down
-  clean [pool]             prune work dirs, temp, diagnostics, old binaries, caches
-  pause|resume             global kill switch (default resumed)
-  schedule install|remove  the background agents that run tick and clean
+Options:
+  -h, --help                    display help for command
 
-Routing lives in each repository's workflow (runs-on), not here. This tool
-controls only whether runners are running.
+Commands:
+  register <pool> [options]     Create a runner pool and leave it stopped
+  set-count <pool> <n>          Change a pool's runner count
+  apply [options]               Reconcile this machine with a pools file
+  up <pool>                     Bring a pool online
+  down <pool>                   Stand a pool down
+  up-all                        Bring every pool online
+  down-all                      Stand every pool down
+  status [options]              Show local state and GitHub's runner state
+  doctor                        Check why a pool is not picking up work
+  pools                         List registered pools
+  stats [options]               Show recorded job durations and queue times
+  reregister <pool>             Recreate a pool's GitHub registrations
+  remove <pool>                 Deregister and delete a pool
+  tick                          Run autoscaling and pool health checks
+  autoscale                     Bring pools up when work is queued
+  sweep                         Stand idle pools down
+  clean [pool]                  Remove runner work, temporary files, and caches
+  pause                         Pause all automatic pool actions
+  resume                        Resume automatic pool actions
+  schedule <install|remove>     Manage the background tick and clean agents
+  help [command]                display help for command
 
-Configuration: ~/.config/runpool/config  (see runpool.conf.example)
-Pools:         ~/.config/runpool/pools   (see runpool.pools.example)
-               override with RUNPOOL_POOLS_FILE, or per run with --file
+Run 'runpool help <command>' for command-specific options and guidance.
 HELP
+      ;;
+    register)
+      cat <<'HELP'
+Usage: runpool register <pool> (--repo OWNER/REPO | --org ORG) [options]
+
+Create a runner pool and leave it stopped.
+
+Options:
+  --repo OWNER/REPO             Register a repository-scoped pool
+  --org ORG                     Register an organisation-scoped pool
+  --count <n>                   Set the runner count (default: 2)
+  --watch OWNER/REPO,...        Repositories an organisation pool watches for work
+  --allow-public                Allow a public repository (repository scope only)
+HELP
+      ;;
+    set-count)
+      echo "Usage: runpool set-count <pool> <n>"
+      ;;
+    apply)
+      cat <<'HELP'
+Usage: runpool apply [options]
+
+Reconcile this machine with a pools file. Pools absent from the file are reported
+but never removed.
+
+Options:
+  --dry-run                     Print the plan without making changes
+  --file <path>                 Read pools from a different file
+HELP
+      ;;
+    up|down)
+      echo "Usage: runpool ${command} <pool>"
+      ;;
+    up-all|down-all|tick|autoscale|sweep|pause|resume|pools|doctor)
+      echo "Usage: runpool ${command}"
+      ;;
+    status)
+      cat <<'HELP'
+Usage: runpool status [options]
+
+Show local runner state alongside GitHub's view.
+
+Options:
+  --json                        Output machine-readable JSON
+  --local                       Skip the GitHub query
+HELP
+      ;;
+    stats)
+      cat <<'HELP'
+Usage: runpool stats [options]
+
+Show recorded job durations.
+
+Options:
+  --queue                       Join records to GitHub to include queue times
+HELP
+      ;;
+    reregister|remove)
+      echo "Usage: runpool ${command} <pool>"
+      ;;
+    clean)
+      echo "Usage: runpool clean [pool]"
+      ;;
+    schedule)
+      echo "Usage: runpool schedule <install|remove>"
+      ;;
+    *)
+      _rp_err "unknown command: ${command}"
+      return 2
+      ;;
+  esac
 }
 
 cmd="${1:-}"; [ $# -gt 0 ] && shift
+case "${1:-}" in
+  -h|--help) _rp_help "${cmd}"; exit $? ;;
+esac
 case "${cmd}" in
   register)       _rp_register "$@" ;;
   set-count)      _rp_set_count "$@" ;;
@@ -115,6 +180,7 @@ case "${cmd}" in
   resume)         _rp_resume ;;
   schedule)       _rp_schedule "$@" ;;
   rewrite-agents) _rp_rewrite_plists ;;
-  -h|--help|help|"") _rp_help ;;
+  help)           _rp_help "${1:-}" ;;
+  -h|--help|"")  _rp_help ;;
   *) _rp_err "unknown command: ${cmd}"; exit 2 ;;
 esac

--- a/bin/runpool
+++ b/bin/runpool
@@ -74,9 +74,10 @@ Commands:
   autoscale                     Bring pools up when work is queued
   sweep                         Stand idle pools down
   clean [pool]                  Remove runner work, temporary files, and caches
-  pause                         Pause all automatic pool actions
-  resume                        Resume automatic pool actions
+  pause [pool]                  Pause every pool, or one pool persistently
+  resume [pool]                 Resume every pool, or one paused pool
   schedule <install|remove>     Manage the background tick and clean agents
+  migrate-storage [options]     Move a legacy installation to macOS storage
   help [command]                display help for command
 
 Run 'runpool help <command>' for command-specific options and guidance.
@@ -114,8 +115,11 @@ HELP
     up|down)
       echo "Usage: runpool ${command} <pool>"
       ;;
-    up-all|down-all|tick|autoscale|sweep|pause|resume|pools|doctor)
+    up-all|down-all|tick|autoscale|sweep|pools|doctor)
       echo "Usage: runpool ${command}"
+      ;;
+    pause|resume)
+      echo "Usage: runpool ${command} [pool]"
       ;;
     status)
       cat <<'HELP'
@@ -147,6 +151,21 @@ HELP
     schedule)
       echo "Usage: runpool schedule <install|remove>"
       ;;
+    migrate-storage)
+      cat <<'HELP'
+Usage: runpool migrate-storage [options]
+
+Copy a stopped legacy installation into Application Support and Caches, then
+rewrite runner work folders and launch agents. The legacy tree is retained
+until it is explicitly removed after verification.
+
+Options:
+  --dry-run                     Print the migration plan without changing files
+  --from <path>                 Read a legacy installation from a different path
+  --to <path>                   Write the migrated installation to a different path
+  --remove-legacy               Remove the source tree after a verified migration
+HELP
+      ;;
     *)
       _rp_err "unknown command: ${command}"
       return 2
@@ -176,9 +195,10 @@ case "${cmd}" in
   autoscale)      _rp_autoscale ;;
   sweep)          _rp_sweep ;;
   clean)          _rp_clean "$@" ;;
-  pause)          _rp_pause ;;
-  resume)         _rp_resume ;;
+  pause)          _rp_pause "$@" ;;
+  resume)         _rp_resume "$@" ;;
   schedule)       _rp_schedule "$@" ;;
+  migrate-storage) _rp_migrate_storage "$@" ;;
   rewrite-agents) _rp_rewrite_plists ;;
   help)           _rp_help "${1:-}" ;;
   -h|--help|"")  _rp_help ;;

--- a/contrib/demo-status.sh
+++ b/contrib/demo-status.sh
@@ -30,10 +30,11 @@ case "$1" in
   "local": false,
   "machine": { "load": 3.2, "cores": 10, "load_warn": 20 },
   "paths": {
-    "base": "/Users/you/.local/share/runpool",
-    "log": "/Users/you/.local/share/runpool/logs/runpool.log",
-    "log_dir": "/Users/you/.local/share/runpool/logs",
-    "telemetry": "/Users/you/.local/share/runpool/telemetry/jobs.jsonl"
+    "base": "/Users/you/Library/Application Support/runpool",
+    "cache": "/Users/you/Library/Caches/runpool",
+    "log": "/Users/you/Library/Logs/runpool/runpool.log",
+    "log_dir": "/Users/you/Library/Logs/runpool",
+    "telemetry": "/Users/you/Library/Application Support/runpool/telemetry/jobs.jsonl"
   },
   "pools": [
     {
@@ -43,6 +44,7 @@ case "$1" in
       "count": 4,
       "running": 4,
       "busy": 2,
+      "paused": false,
       "github_registered": 4,
       "github_online": 4,
       "watch": ["github/docs", "github/linguist", "github/gitignore", "github/scientist", "github/codeql-action"]
@@ -54,6 +56,7 @@ case "$1" in
       "count": 2,
       "running": 2,
       "busy": 0,
+      "paused": false,
       "github_registered": 2,
       "github_online": 2,
       "watch": []
@@ -65,6 +68,7 @@ case "$1" in
       "count": 2,
       "running": 0,
       "busy": 0,
+      "paused": true,
       "github_registered": 2,
       "github_online": 0,
       "watch": []

--- a/contrib/job-hook.sh
+++ b/contrib/job-hook.sh
@@ -17,7 +17,7 @@
 # ~/.config/runpool/config, then: runpool rewrite-agents && runpool down-all
 #
 # Set RUNPOOL_TELEMETRY=1 as well and each job also appends one JSON line to
-# <base>/telemetry/jobs.jsonl. That is what `runpool stats` reads. It records
+# Application Support/runpool/telemetry/jobs.jsonl. That is what `runpool stats` reads. It records
 # nothing about the code, only timings and machine state, and it never leaves
 # the machine.
 #
@@ -32,7 +32,16 @@ phase="${1:-started}"
 RUNPOOL_CONFIG="${RUNPOOL_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpool/config}"
 # shellcheck disable=SC1090
 [ -f "${RUNPOOL_CONFIG}" ] && . "${RUNPOOL_CONFIG}" 2>/dev/null
-RUNPOOL_BASE="${RUNPOOL_BASE:-${XDG_DATA_HOME:-${HOME}/.local/share}/runpool}"
+if [ -z "${RUNPOOL_BASE:-}" ]; then
+  RUNPOOL_DEFAULT_BASE="${HOME}/Library/Application Support/runpool"
+  RUNPOOL_LEGACY_BASE="${XDG_DATA_HOME:-${HOME}/.local/share}/runpool"
+  if find "${RUNPOOL_LEGACY_BASE}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q . && \
+     ! find "${RUNPOOL_DEFAULT_BASE}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q .; then
+    RUNPOOL_BASE="${RUNPOOL_LEGACY_BASE}"
+  else
+    RUNPOOL_BASE="${RUNPOOL_DEFAULT_BASE}"
+  fi
+fi
 RUNPOOL_TELEMETRY="${RUNPOOL_TELEMETRY:-0}"
 
 load1="$(sysctl -n vm.loadavg 2>/dev/null | tr -d '{}' | awk '{print $1}')" || load1="0"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -18,6 +18,7 @@ RUNPOOL_CONFIG="${RUNPOOL_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpool/co
 # invocation at a scratch directory. That matters for anything testing this
 # on a machine that already has a config, the Homebrew test block included.
 _rp_env_BASE="${RUNPOOL_BASE:-}"
+_rp_env_CACHE_DIR="${RUNPOOL_CACHE_DIR:-}"
 _rp_env_POOLS_FILE="${RUNPOOL_POOLS_FILE:-}"
 _rp_env_LOG_DIR="${RUNPOOL_LOG_DIR:-}"
 _rp_env_LABEL_NS="${RUNPOOL_LABEL_NS:-}"
@@ -38,6 +39,7 @@ set -a
 set +a
 
 [ -n "${_rp_env_BASE}" ]        && RUNPOOL_BASE="${_rp_env_BASE}"
+[ -n "${_rp_env_CACHE_DIR}" ]   && RUNPOOL_CACHE_DIR="${_rp_env_CACHE_DIR}"
 [ -n "${_rp_env_POOLS_FILE}" ]  && RUNPOOL_POOLS_FILE="${_rp_env_POOLS_FILE}"
 [ -n "${_rp_env_LOG_DIR}" ]     && RUNPOOL_LOG_DIR="${_rp_env_LOG_DIR}"
 [ -n "${_rp_env_LABEL_NS}" ]    && RUNPOOL_LABEL_NS="${_rp_env_LABEL_NS}"
@@ -46,20 +48,46 @@ set +a
 [ -n "${_rp_env_NOTIFY_CMD}" ]  && RUNPOOL_NOTIFY_CMD="${_rp_env_NOTIFY_CMD}"
 [ -n "${_rp_env_JOB_HOOK}" ]    && RUNPOOL_JOB_HOOK="${_rp_env_JOB_HOOK}"
 [ -n "${_rp_env_TELEMETRY}" ]   && RUNPOOL_TELEMETRY="${_rp_env_TELEMETRY}"
-unset _rp_env_BASE _rp_env_POOLS_FILE _rp_env_LOG_DIR _rp_env_LABEL_NS \
+unset _rp_env_BASE _rp_env_CACHE_DIR _rp_env_POOLS_FILE _rp_env_LOG_DIR _rp_env_LABEL_NS \
       _rp_env_IDLE_SECS _rp_env_LOAD_WARN _rp_env_NOTIFY_CMD _rp_env_JOB_HOOK \
       _rp_env_TELEMETRY
 
 # Restored values need exporting again: the restore above is a plain assignment
 # and happens after 'set -a' was turned off.
-export RUNPOOL_BASE RUNPOOL_LOG_DIR RUNPOOL_LABEL_NS RUNPOOL_IDLE_SECS \
+export RUNPOOL_BASE RUNPOOL_CACHE_DIR RUNPOOL_LOG_DIR RUNPOOL_LABEL_NS RUNPOOL_IDLE_SECS \
        RUNPOOL_LOAD_WARN RUNPOOL_NOTIFY_CMD RUNPOOL_JOB_HOOK RUNPOOL_TELEMETRY \
        RUNPOOL_CONFIG RUNPOOL_POOLS_FILE
 
-# Where runners, pool definitions, launch agents and state live. Never the
-# repository: it holds registration credentials.
-RUNPOOL_BASE="${RUNPOOL_BASE:-${XDG_DATA_HOME:-${HOME}/.local/share}/runpool}"
+# Required state belongs in Application Support. Runner installations carry
+# registration credentials, so they are not cache data and never belong in a
+# checkout. An existing pre-native-storage installation remains active until
+# the operator explicitly migrates it; silently switching roots would strand
+# its registrations and leave launch agents pointing at the old tree.
+RUNPOOL_DEFAULT_BASE="${HOME}/Library/Application Support/runpool"
+RUNPOOL_LEGACY_BASE="${XDG_DATA_HOME:-${HOME}/.local/share}/runpool"
+# shellcheck disable=SC2034  # read by migrate-storage in lib/lifecycle.sh
+RUNPOOL_USING_LEGACY=0
+if [ -z "${RUNPOOL_BASE:-}" ]; then
+  # An empty Application Support directory is not an installation. This can
+  # happen when a user created the directory while reading the release notes;
+  # it must not make a populated legacy installation disappear from RunPool.
+  if find "${RUNPOOL_LEGACY_BASE}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q . && \
+     ! find "${RUNPOOL_DEFAULT_BASE}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q .; then
+    RUNPOOL_BASE="${RUNPOOL_LEGACY_BASE}"
+    # shellcheck disable=SC2034  # read by migrate-storage in lib/lifecycle.sh
+    RUNPOOL_USING_LEGACY=1
+  else
+    RUNPOOL_BASE="${RUNPOOL_DEFAULT_BASE}"
+  fi
+fi
+
+# Work trees, actions, tools, package stores, temporary files and downloaded
+# runner archives are all safe to recreate. They stay outside Application
+# Support so macOS can treat them as cache data and so cleaning never touches
+# registration state.
+RUNPOOL_CACHE_DIR="${RUNPOOL_CACHE_DIR:-${HOME}/Library/Caches/runpool}"
 RUNPOOL_POOL_DIR="${RUNPOOL_BASE}/pools"
+RUNPOOL_RUNNER_DIR="${RUNPOOL_BASE}/runners"
 RUNPOOL_AGENT_DIR="${RUNPOOL_BASE}/agents"
 RUNPOOL_STATE_DIR="${RUNPOOL_BASE}/state"
 RUNPOOL_LOG_DIR="${RUNPOOL_LOG_DIR:-${HOME}/Library/Logs/runpool}"
@@ -67,6 +95,7 @@ RUNPOOL_LOG_DIR="${RUNPOOL_LOG_DIR:-${HOME}/Library/Logs/runpool}"
 RUNPOOL_LOG="${RUNPOOL_LOG_DIR}/runpool.log"
 RUNPOOL_ACTIVITY="${RUNPOOL_STATE_DIR}/activity"
 RUNPOOL_PAUSE_FLAG="${RUNPOOL_STATE_DIR}/paused"
+RUNPOOL_POOL_PAUSE_DIR="${RUNPOOL_STATE_DIR}/pools"
 # shellcheck disable=SC2034  # read by lib/scheduler.sh
 RUNPOOL_LAST_CLEAN="${RUNPOOL_STATE_DIR}/last-clean"
 
@@ -106,8 +135,9 @@ RUNPOOL_NOTIFY_CMD="${RUNPOOL_NOTIFY_CMD:-}"
 # machine state only, nothing about the code, and it never leaves the machine.
 RUNPOOL_TELEMETRY="${RUNPOOL_TELEMETRY:-0}"
 
-mkdir -p "${RUNPOOL_POOL_DIR}" "${RUNPOOL_AGENT_DIR}" \
-         "${RUNPOOL_STATE_DIR}" "${RUNPOOL_LOG_DIR}" 2>/dev/null || true
+mkdir -p "${RUNPOOL_POOL_DIR}" "${RUNPOOL_RUNNER_DIR}" "${RUNPOOL_AGENT_DIR}" \
+         "${RUNPOOL_STATE_DIR}" "${RUNPOOL_POOL_PAUSE_DIR}" "${RUNPOOL_CACHE_DIR}" \
+         "${RUNPOOL_LOG_DIR}" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Output
@@ -222,13 +252,19 @@ _rp_load_pool() {
     _rp_err "unknown pool: $1 (see 'runpool pools')"; return 1
   fi
   POOL_NAME=""; POOL_SCOPE=""; POOL_TARGET=""; POOL_COUNT=""
-  POOL_DIR=""; POOL_LABELS=""; POOL_WATCH=""
+  POOL_DIR=""; POOL_CACHE_DIR=""; POOL_LABELS=""; POOL_WATCH=""; POOL_LEGACY_LAYOUT=0
   # shellcheck disable=SC1090
   . "${conf}" || { _rp_err "pool '$1': could not read ${conf}"; return 1; }
   if [ -z "${POOL_SCOPE}" ] || [ -z "${POOL_TARGET}" ] || \
      [ -z "${POOL_COUNT}" ] || [ -z "${POOL_DIR}" ]; then
     _rp_err "pool '$1': ${conf} is incomplete (needs POOL_SCOPE, POOL_TARGET, POOL_COUNT and POOL_DIR)"
     return 1
+  fi
+  # Pool configs before native storage have no cache root. Keep their work and
+  # package stores exactly where they are until migrate-storage rewrites them.
+  if [ -z "${POOL_CACHE_DIR}" ]; then
+    POOL_CACHE_DIR="${POOL_DIR}"
+    POOL_LEGACY_LAYOUT=1
   fi
 }
 
@@ -255,6 +291,27 @@ _rp_agent_loaded() { launchctl list "$1" >/dev/null 2>&1; }
 _rp_touch_activity() { _rp_now >| "${RUNPOOL_ACTIVITY}"; }
 
 _rp_paused() { [ -f "${RUNPOOL_PAUSE_FLAG}" ]; }
+_rp_pool_pause_flag() { echo "${RUNPOOL_POOL_PAUSE_DIR}/$1.paused"; }
+_rp_pool_paused() { [ -f "$(_rp_pool_pause_flag "$1")" ]; }
+
+_rp_runner_cache_dir() { echo "${POOL_CACHE_DIR}/runner-$2"; }
+_rp_runner_work_dir() {
+  if [ "${POOL_LEGACY_LAYOUT}" = "1" ]; then
+    echo "${POOL_DIR}/runner-$2/_work"
+  else
+    echo "${POOL_CACHE_DIR}/runner-$2/work"
+  fi
+}
+
+_rp_prepare_runner_cache() {
+  local cache
+  cache="$(_rp_runner_cache_dir "$1" "$2")"
+  if [ "${POOL_LEGACY_LAYOUT}" = "1" ]; then
+    mkdir -p "${cache}/_work" "${cache}/.pnpm-store" "${cache}/.npm-cache" "${cache}/tmp" 2>/dev/null
+  else
+    mkdir -p "${cache}/work" "${cache}/pnpm" "${cache}/npm" "${cache}/tmp" 2>/dev/null
+  fi
+}
 
 # GitHub API prefix for a pool's scope: orgs/<org> or repos/<owner>/<repo>.
 _rp_scope_path() {
@@ -309,8 +366,8 @@ _rp_fetch_runner_tarball() {
   done
   url="${out%% *}"; digest="${out#* }"
   [ -n "${url}" ] || { _rp_err "could not resolve the osx-arm64 runner tarball after retries"; return 1; }
-  path="${RUNPOOL_BASE}/.cache/${url##*/}"
-  mkdir -p "${RUNPOOL_BASE}/.cache" 2>/dev/null
+  path="${RUNPOOL_CACHE_DIR}/downloads/${url##*/}"
+  mkdir -p "${RUNPOOL_CACHE_DIR}/downloads" 2>/dev/null
   if [ ! -f "${path}" ]; then
     _rp_log "downloading runner: ${url##*/}"
     # '-f' so an HTTP error is a failure. Without it curl writes the error body
@@ -388,7 +445,16 @@ WRAP
 # never starts a runner at login. Pools come up because something asked, or
 # because the tick saw queued work.
 _rp_write_plist() {
-  local label="$1" dir="$2" plist="${RUNPOOL_AGENT_DIR}/$1.plist" hook=""
+  local label="$1" dir="$2" cache_dir="$3" legacy_layout="$4" plist="${RUNPOOL_AGENT_DIR}/$1.plist" hook="" pnpm_dir npm_dir tmp_dir
+  if [ "${legacy_layout}" = "1" ]; then
+    pnpm_dir="${dir}/.pnpm-store"
+    npm_dir="${dir}/.npm-cache"
+    tmp_dir="${dir}/tmp"
+  else
+    pnpm_dir="${cache_dir}/pnpm"
+    npm_dir="${cache_dir}/npm"
+    tmp_dir="${cache_dir}/tmp"
+  fi
   [ -n "${RUNPOOL_JOB_HOOK:-}" ] && { _rp_write_hook_wrappers; hook="${RUNPOOL_BASE}/hooks"; }
   {
     cat <<PLIST
@@ -409,11 +475,11 @@ _rp_write_plist() {
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>npm_config_store_dir</key>
-    <string>${dir}/.pnpm-store</string>
+    <string>${pnpm_dir}</string>
     <key>npm_config_cache</key>
-    <string>${dir}/.npm-cache</string>
+    <string>${npm_dir}</string>
     <key>TMPDIR</key>
-    <string>${dir}/tmp</string>
+    <string>${tmp_dir}</string>
 PLIST
     if [ -n "${hook}" ]; then
       cat <<PLIST
@@ -465,7 +531,9 @@ _rp_rewrite_plists() {
     _rp_load_pool "${p}" || continue
     i=1
     while [ "${i}" -le "${POOL_COUNT}" ]; do
-      _rp_write_plist "$(_rp_label "${p}" "${i}")" "${POOL_DIR}/runner-${i}"
+      _rp_prepare_runner_cache "${p}" "${i}"
+      _rp_write_plist "$(_rp_label "${p}" "${i}")" "${POOL_DIR}/runner-${i}" \
+                      "$(_rp_runner_cache_dir "${p}" "${i}")" "${POOL_LEGACY_LAYOUT}"
       i=$(( i + 1 ))
     done
     _rp_log "rewrote agents for pool '${p}'"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -113,7 +113,7 @@ mkdir -p "${RUNPOOL_POOL_DIR}" "${RUNPOOL_AGENT_DIR}" \
 # Output
 # ---------------------------------------------------------------------------
 _rp_log() {
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "${RUNPOOL_LOG}" >&2
+  echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC')  $*" | tee -a "${RUNPOOL_LOG}" >&2
 }
 _rp_err() { echo "runpool: $*" >&2; }
 

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -371,7 +371,7 @@ _rp_up() {
     i=$(( i + 1 ))
   done
   _rp_touch_activity
-  _rp_log "up '$1': ${loaded}/${POOL_COUNT} runner(s) online"
+  _rp_log "Started pool '$1' (${loaded} of ${POOL_COUNT} runners online)."
 }
 
 # Refuses while a job is in flight unless --force. Unloading a launch agent
@@ -395,7 +395,7 @@ _rp_down() {
     _rp_agent_loaded "${label}" && launchctl unload "${plist}" 2>/dev/null
     i=$(( i + 1 ))
   done
-  _rp_log "down '$1': runners stopped (still registered, offline)"
+  _rp_log "Stopped pool '$1'. Runners remain registered."
 }
 
 _rp_up_all()   { local p; for p in $(_rp_pool_names); do _rp_up "${p}"; done; }

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -136,8 +136,9 @@ _rp_register() {
     esac
   fi
 
-  local dir_base labels tarball i runner_dir runner_name token
-  dir_base="${RUNPOOL_BASE}/${name}"
+  local dir_base cache_base labels tarball i runner_dir cache_dir runner_name token
+  dir_base="${RUNPOOL_RUNNER_DIR}/${name}"
+  cache_base="${RUNPOOL_CACHE_DIR}/pools/${name}"
   labels="self-hosted,macOS,ARM64,${name}"
   tarball="$(_rp_fetch_runner_tarball)" || return 1
   mkdir -p "${dir_base}"
@@ -145,10 +146,12 @@ _rp_register() {
   i=1
   while [ "${i}" -le "${count}" ]; do
     runner_dir="${dir_base}/runner-${i}"
+    cache_dir="${cache_base}/runner-${i}"
     if [ -f "${runner_dir}/.runner" ]; then
       _rp_log "${name} runner-${i}: already registered, skipping"
     else
       mkdir -p "${runner_dir}"
+      mkdir -p "${cache_dir}/work" "${cache_dir}/pnpm" "${cache_dir}/npm" "${cache_dir}/tmp"
       [ -f "${runner_dir}/config.sh" ] || tar -xzf "${tarball}" -C "${runner_dir}" || return 1
       token=$(gh api -X POST "$(_rp_scope_path "${scope}" "${target}")/actions/runners/registration-token" \
                 --jq '.token' 2>/dev/null)
@@ -157,10 +160,10 @@ _rp_register() {
       _rp_log "${name} runner-${i}: registering as '${runner_name}'"
       ( cd "${runner_dir}" && ./config.sh --unattended --replace \
           --url "https://github.com/${target}" --token "${token}" \
-          --name "${runner_name}" --labels "${labels}" --work "_work" \
+          --name "${runner_name}" --labels "${labels}" --work "${cache_dir}/work" \
           >> "${RUNPOOL_LOG}" 2>&1 ) || return 1
     fi
-    _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}"
+    _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}" "${cache_dir}" 0
     i=$(( i + 1 ))
   done
 
@@ -177,6 +180,7 @@ POOL_SCOPE="${scope}"
 POOL_TARGET="${target}"
 POOL_COUNT="${count}"
 POOL_DIR="${dir_base}"
+POOL_CACHE_DIR="${cache_base}"
 POOL_LABELS="${labels}"
 CONF
     if [ -n "${watch}" ]; then printf 'POOL_WATCH="%s"\n' "${watch}"; fi
@@ -246,7 +250,7 @@ _rp_set_count() {
     return 1
   fi
 
-  local was_up=0 i runner_dir label token runner_name tarball
+  local was_up=0 i runner_dir cache_dir label token runner_name tarball
   _rp_agent_loaded "$(_rp_label "${name}" 1)" && was_up=1
 
   if [ "${want}" -gt "${have}" ]; then
@@ -254,7 +258,9 @@ _rp_set_count() {
     i=$(( have + 1 ))
     while [ "${i}" -le "${want}" ]; do
       runner_dir="${POOL_DIR}/runner-${i}"
+      cache_dir="$(_rp_runner_cache_dir "${name}" "${i}")"
       mkdir -p "${runner_dir}"
+      _rp_prepare_runner_cache "${name}" "${i}"
       [ -f "${runner_dir}/config.sh" ] || tar -xzf "${tarball}" -C "${runner_dir}" || return 1
       if [ ! -f "${runner_dir}/.runner" ]; then
         token=$(gh api -X POST "$(_rp_scope_path "${POOL_SCOPE}" "${POOL_TARGET}")/actions/runners/registration-token" \
@@ -264,10 +270,10 @@ _rp_set_count() {
         _rp_log "${name} runner-${i}: registering as '${runner_name}'"
         ( cd "${runner_dir}" && ./config.sh --unattended --replace \
             --url "https://github.com/${POOL_TARGET}" --token "${token}" \
-            --name "${runner_name}" --labels "${POOL_LABELS}" --work "_work" \
+            --name "${runner_name}" --labels "${POOL_LABELS}" --work "$(_rp_runner_work_dir "${name}" "${i}")" \
             >> "${RUNPOOL_LOG}" 2>&1 ) || return 1
       fi
-      _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}"
+      _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}" "${cache_dir}" "${POOL_LEGACY_LAYOUT}"
       i=$(( i + 1 ))
     done
   else
@@ -284,6 +290,7 @@ _rp_set_count() {
     i=$(( want + 1 ))
     while [ "${i}" -le "${have}" ]; do
       runner_dir="${POOL_DIR}/runner-${i}"
+      cache_dir="$(_rp_runner_cache_dir "${name}" "${i}")"
       label="$(_rp_label "${name}" "${i}")"
       _rp_agent_loaded "${label}" && launchctl unload "${RUNPOOL_AGENT_DIR}/${label}.plist" 2>/dev/null
       # Deregister before deleting. A runner removed locally but left
@@ -292,6 +299,7 @@ _rp_set_count() {
       _rp_deregister_runner "${runner_dir}" "${POOL_SCOPE}" "${POOL_TARGET}"
       rm -f "${RUNPOOL_AGENT_DIR}/${label}.plist"
       rm -rf "${runner_dir}"
+      [ "${POOL_LEGACY_LAYOUT}" = "1" ] || rm -rf "${cache_dir}"
       _rp_log "${name} runner-${i}: removed"
       i=$(( i + 1 ))
     done
@@ -303,7 +311,9 @@ _rp_set_count() {
   # here is a harmless no-op that keeps one exit path for both.
   _rp_write_pool_count "${name}" "${want}"
   _rp_log "pool '${name}': ${have} -> ${want} runner(s)"
-  [ "${was_up}" = "1" ] && { _rp_load_pool "${name}" && _rp_up "${name}"; }
+  if [ "${was_up}" = "1" ] && ! _rp_pool_paused "${name}"; then
+    _rp_load_pool "${name}" && _rp_up "${name}"
+  fi
   return 0
 }
 
@@ -321,7 +331,7 @@ _rp_reregister() {
   local name="$1"
   [ -n "${name}" ] || { _rp_err "usage: runpool reregister <pool>"; return 1; }
   _rp_load_pool "${name}" || return 1
-  _rp_down "${name}" >/dev/null 2>&1
+  _rp_down "${name}" || return 1
 
   local i runner_dir runner_name token
   i=1
@@ -343,12 +353,227 @@ _rp_reregister() {
     _rp_log "${name} runner-${i}: re-registering as '${runner_name}'"
     ( cd "${runner_dir}" && ./config.sh --unattended --replace \
         --url "https://github.com/${POOL_TARGET}" --token "${token}" \
-        --name "${runner_name}" --labels "${POOL_LABELS}" --work "_work" \
+        --name "${runner_name}" --labels "${POOL_LABELS}" --work "$(_rp_runner_work_dir "${name}" "${i}")" \
         >> "${RUNPOOL_LOG}" 2>&1 ) || return 1
-    _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}"
+    _rp_prepare_runner_cache "${name}" "${i}"
+    _rp_write_plist "$(_rp_label "${name}" "${i}")" "${runner_dir}" \
+                    "$(_rp_runner_cache_dir "${name}" "${i}")" "${POOL_LEGACY_LAYOUT}"
     i=$(( i + 1 ))
   done
   _rp_log "pool '${name}': ${POOL_COUNT} runner(s) re-registered (stopped)"
+}
+
+# ---------------------------------------------------------------------------
+# migrate-storage — copy a legacy installation into macOS-native roots
+# ---------------------------------------------------------------------------
+# The migration copies first and leaves the old tree alone. A runner's
+# registration credentials stay valid after its files and workFolder move, but
+# a failed copy must never turn a recoverable layout change into a lost pool.
+# --remove-legacy is deliberately a separate, explicit operation after the
+# new tree has been checked.
+_rp_migrate_pool_names() {
+  find "$1/pools" -maxdepth 1 -name '*.conf' 2>/dev/null \
+    | while read -r f; do basename "${f}" .conf; done
+}
+
+_rp_migrate_update_pool_conf() {
+  local conf="$1" runner_dir="$2" cache_dir="$3" tmp
+  tmp="${conf}.tmp"
+  awk -v runner_dir="${runner_dir}" -v cache_dir="${cache_dir}" '
+    /^POOL_DIR=/ { print "POOL_DIR=\"" runner_dir "\""; next }
+    /^POOL_CACHE_DIR=/ { print "POOL_CACHE_DIR=\"" cache_dir "\""; cache_seen=1; next }
+    { print }
+    END { if (!cache_seen) print "POOL_CACHE_DIR=\"" cache_dir "\"" }
+  ' "${conf}" >| "${tmp}" && mv -f "${tmp}" "${conf}"
+}
+
+_rp_migrate_update_config_base() {
+  local source="$1" target="$2" tmp mode
+  [ -f "${RUNPOOL_CONFIG}" ] || return 0
+  grep -q '^RUNPOOL_BASE=' "${RUNPOOL_CONFIG}" || return 0
+  tmp="${RUNPOOL_CONFIG}.tmp"
+  mode=$(stat -f '%Lp' "${RUNPOOL_CONFIG}" 2>/dev/null) || return 1
+  awk -v target="${target}" '
+    /^RUNPOOL_BASE=/ { print "RUNPOOL_BASE=\"" target "\""; changed=1; next }
+    { print }
+  ' "${RUNPOOL_CONFIG}" >| "${tmp}" || return 1
+  chmod "${mode}" "${tmp}" || return 1
+  mv -f "${tmp}" "${RUNPOOL_CONFIG}" || return 1
+  _rp_log "Updated RUNPOOL_BASE in ${RUNPOOL_CONFIG}: ${source} -> ${target}"
+}
+
+_rp_migrate_update_work_folder() {
+  local runner_dir="$1" work_dir="$2" work_escaped tmp
+  [ -f "${runner_dir}/.runner" ] || return 0
+  grep -q '"workFolder"' "${runner_dir}/.runner" || {
+    _rp_err "${runner_dir}/.runner has no workFolder setting"
+    return 1
+  }
+  work_escaped=$(printf '%s' "${work_dir}" | sed 's/[\\&|]/\\&/g')
+  tmp="${runner_dir}/.runner.tmp"
+  sed -E "s|(\"workFolder\"[[:space:]]*:[[:space:]]*)\"[^\"]*\"|\\1\"${work_escaped}\"|" \
+    "${runner_dir}/.runner" >| "${tmp}" && mv -f "${tmp}" "${runner_dir}/.runner"
+}
+
+_rp_migrate_move_cache_dir() {
+  local from="$1" to="$2"
+  [ -d "${from}" ] || return 0
+  [ ! -e "${to}" ] || { _rp_err "migration target already has ${to}"; return 1; }
+  mkdir -p "$(dirname "${to}")" || return 1
+  mv "${from}" "${to}"
+}
+
+_rp_migrate_storage() {
+  local dry=0 remove_legacy=0 source="" target="" active_base="${RUNPOOL_BASE}" arg p conf old_dir new_dir cache_pool i runner_dir cache_dir busy=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry=1; shift ;;
+      --remove-legacy) remove_legacy=1; shift ;;
+      --from|--to)
+        [ $# -ge 2 ] || { _rp_err "$1 needs a path"; return 1; }
+        if [ "$1" = "--from" ]; then source="$2"; else target="$2"; fi
+        shift 2
+        ;;
+      *) _rp_err "unknown flag: $1 (usage: runpool migrate-storage [--dry-run] [--from PATH] [--to PATH] [--remove-legacy])"; return 1 ;;
+    esac
+  done
+
+  if [ -z "${source}" ]; then
+    if [ "${RUNPOOL_BASE}" != "${RUNPOOL_DEFAULT_BASE}" ] && [ -d "${RUNPOOL_BASE}/pools" ]; then
+      source="${RUNPOOL_BASE}"
+    elif [ -d "${RUNPOOL_LEGACY_BASE}" ]; then
+      source="${RUNPOOL_LEGACY_BASE}"
+    else
+      _rp_err "no legacy installation was found (expected ${RUNPOOL_LEGACY_BASE})"
+      return 1
+    fi
+  fi
+  if [ -z "${target}" ]; then
+    if [ "${source}" = "${RUNPOOL_BASE}" ] && [ "${source}" != "${RUNPOOL_DEFAULT_BASE}" ]; then
+      target="${RUNPOOL_DEFAULT_BASE}"
+    else
+      target="${RUNPOOL_BASE}"
+    fi
+  fi
+  [ -d "${source}" ] || { _rp_err "legacy installation not found: ${source}"; return 1; }
+  [ "${source}" != "${target}" ] || { _rp_err "migration source and target are both ${source}"; return 1; }
+
+  if [ "${remove_legacy}" = "1" ]; then
+    find "${target}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q . || {
+      _rp_err "no migrated pool definitions at ${target}"
+      return 1
+    }
+    [ "${dry}" = "1" ] && { echo "Would remove legacy installation: ${source}"; return 0; }
+    rm -rf "${source}"
+    _rp_log "Removed legacy installation: ${source}"
+    return 0
+  fi
+
+  [ -d "${source}/pools" ] || { _rp_err "${source} has no pool definitions"; return 1; }
+  if find "${target}/pools" -maxdepth 1 -name '*.conf' 2>/dev/null | grep -q .; then
+    _rp_err "migration target already has pool definitions: ${target}"
+    return 1
+  fi
+
+  for p in $(_rp_migrate_pool_names "${source}"); do
+    conf="${source}/pools/${p}.conf"
+    POOL_COUNT=""; POOL_DIR=""
+    # shellcheck disable=SC1090
+    . "${conf}" || { _rp_err "could not read ${conf}"; return 1; }
+    [ -n "${POOL_DIR}" ] && [ -n "${POOL_COUNT}" ] || { _rp_err "${conf} is incomplete"; return 1; }
+    busy=$(( busy + $(_rp_busy_in "${POOL_DIR}") ))
+  done
+  if [ "${busy}" -gt 0 ]; then
+    _rp_err "${busy} job(s) are running — refusing to migrate. Wait for them to finish, then retry."
+    return 1
+  fi
+
+  echo "Storage migration"
+  echo "  From: ${source}"
+  echo "  To:   ${target}"
+  echo "  Cache: ${RUNPOOL_CACHE_DIR}"
+  for p in $(_rp_migrate_pool_names "${source}"); do echo "  Pool: ${p}"; done
+  if [ "${dry}" = "1" ]; then
+    echo "  Dry run: no files or launch agents were changed."
+    return 0
+  fi
+
+  # A listener with no job is still a live runner process. Work is already
+  # known idle above, so unloading these agents is safe and prevents the old
+  # tree from continuing to serve jobs after the copied agents are rewritten.
+  for p in $(_rp_migrate_pool_names "${source}"); do
+    conf="${source}/pools/${p}.conf"
+    POOL_COUNT=""
+    # shellcheck disable=SC1090
+    . "${conf}" || return 1
+    i=1
+    while [ "${i}" -le "${POOL_COUNT}" ]; do
+      launchctl unload "${source}/agents/$(_rp_label "${p}" "${i}").plist" 2>/dev/null || true
+      i=$(( i + 1 ))
+    done
+  done
+
+  mkdir -p "${target}/pools" "${target}/runners" "${target}/agents" "${target}/state" \
+           "${target}/state/pools" "${target}/hooks" "${target}/telemetry" \
+           "${RUNPOOL_CACHE_DIR}/downloads" || return 1
+  for p in $(_rp_migrate_pool_names "${source}"); do
+    conf="${source}/pools/${p}.conf"
+    POOL_COUNT=""; POOL_DIR=""
+    # shellcheck disable=SC1090
+    . "${conf}" || return 1
+    old_dir="${POOL_DIR}"
+    new_dir="${target}/runners/${p}"
+    cache_pool="${RUNPOOL_CACHE_DIR}/pools/${p}"
+    [ ! -e "${new_dir}" ] || { _rp_err "migration target already has ${new_dir}"; return 1; }
+    cp -R "${old_dir}" "${new_dir}" || return 1
+    cp "${conf}" "${target}/pools/${p}.conf" || return 1
+    i=1
+    while [ "${i}" -le "${POOL_COUNT}" ]; do
+      runner_dir="${new_dir}/runner-${i}"
+      cache_dir="${cache_pool}/runner-${i}"
+      mkdir -p "${cache_dir}" || return 1
+      _rp_migrate_move_cache_dir "${runner_dir}/_work" "${cache_dir}/work" || return 1
+      _rp_migrate_move_cache_dir "${runner_dir}/.pnpm-store" "${cache_dir}/pnpm" || return 1
+      _rp_migrate_move_cache_dir "${runner_dir}/.npm-cache" "${cache_dir}/npm" || return 1
+      if [ -d "${runner_dir}/tmp" ]; then
+        _rp_migrate_move_cache_dir "${runner_dir}/tmp" "${cache_dir}/tmp" || return 1
+      elif [ -d "${runner_dir}/.tmp" ]; then
+        _rp_migrate_move_cache_dir "${runner_dir}/.tmp" "${cache_dir}/tmp" || return 1
+      fi
+      mkdir -p "${cache_dir}/work" "${cache_dir}/pnpm" "${cache_dir}/npm" "${cache_dir}/tmp" || return 1
+      _rp_migrate_update_work_folder "${runner_dir}" "${cache_dir}/work" || return 1
+      i=$(( i + 1 ))
+    done
+    _rp_migrate_update_pool_conf "${target}/pools/${p}.conf" "${new_dir}" "${cache_pool}" || return 1
+  done
+  for arg in agents state hooks telemetry; do
+    if [ -d "${source}/${arg}" ]; then
+      cp -R "${source}/${arg}/." "${target}/${arg}/" || return 1
+    fi
+  done
+  if [ -d "${source}/.cache" ]; then
+    cp -R "${source}/.cache/." "${RUNPOOL_CACHE_DIR}/downloads/" || return 1
+  fi
+  if [ "${active_base}" = "${source}" ] && [ "${target}" != "${source}" ]; then
+    _rp_migrate_update_config_base "${source}" "${target}" || return 1
+  fi
+
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_BASE="${target}"
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_POOL_DIR="${RUNPOOL_BASE}/pools"
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_RUNNER_DIR="${RUNPOOL_BASE}/runners"
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_AGENT_DIR="${RUNPOOL_BASE}/agents"
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_STATE_DIR="${RUNPOOL_BASE}/state"
+  # shellcheck disable=SC2034  # read by lib/common.sh helpers below
+  RUNPOOL_POOL_PAUSE_DIR="${RUNPOOL_STATE_DIR}/pools"
+  _rp_rewrite_plists || return 1
+  _rp_log "Migrated storage to ${target}. Legacy data remains at ${source}."
+  _rp_log "Verify with: runpool status --local && runpool doctor"
+  _rp_log "After verification, remove it with: runpool migrate-storage --from ${source} --to ${target} --remove-legacy"
 }
 
 # ---------------------------------------------------------------------------
@@ -357,6 +582,7 @@ _rp_reregister() {
 _rp_up() {
   _rp_load_pool "$1" || return 1
   if _rp_paused; then _rp_err "runpool is paused — run 'runpool resume' first"; return 1; fi
+  if _rp_pool_paused "$1"; then _rp_err "pool '$1' is paused — run 'runpool resume $1' first"; return 1; fi
   local i label plist loaded=0
   i=1
   while [ "${i}" -le "${POOL_COUNT}" ]; do
@@ -398,7 +624,7 @@ _rp_down() {
   _rp_log "Stopped pool '$1'. Runners remain registered."
 }
 
-_rp_up_all()   { local p; for p in $(_rp_pool_names); do _rp_up "${p}"; done; }
+_rp_up_all()   { local p; for p in $(_rp_pool_names); do _rp_pool_paused "${p}" || _rp_up "${p}"; done; }
 _rp_down_all() { local p; for p in $(_rp_pool_names); do _rp_down "${p}" "${1:-}"; done; }
 
 # ---------------------------------------------------------------------------
@@ -425,6 +651,8 @@ _rp_remove() {
   if [ "${POOL_DIR}" != "${RUNPOOL_BASE}" ]; then
     case "${POOL_DIR}" in "${RUNPOOL_BASE}/"*) rm -rf "${POOL_DIR}" ;; esac
   fi
+  [ "${POOL_LEGACY_LAYOUT}" = "1" ] || rm -rf "${POOL_CACHE_DIR}"
+  rm -f "$(_rp_pool_pause_flag "$1")"
   rm -f "$(_rp_pool_conf "$1")"
   _rp_log "pool '$1' removed"
 }

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -93,6 +93,7 @@ _rp_status() {
       esac
     fi
 
+    _rp_pool_paused "${p}" && note="  (paused)${note}"
     printf "  %-10s %-6s %-20s %7s %5s  %s%s\n" \
       "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${running}/${POOL_COUNT}" \
       "${busy}" "${gh_display}" "${note}"
@@ -121,7 +122,7 @@ _rp_status() {
 # is thousands a day, and it makes a passive readout fail whenever the network
 # does, which is the opposite of what a passive readout is for.
 _rp_status_json() {
-  local local_only="${1:-0}" p running busy gh reg online first=1 paused="false" wr wfirst
+  local local_only="${1:-0}" p running busy gh reg online first=1 paused="false" pool_paused="false" wr wfirst
   _rp_paused && paused="true"
   # Machine state belongs here rather than being recomputed by every caller.
   # The contention threshold in particular is configurable, so a caller that
@@ -130,10 +131,10 @@ _rp_status_json() {
   local load cores
   load=$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}')
   cores=$(sysctl -n hw.ncpu 2>/dev/null || echo 0)
-  printf '{"paused":%s,"local":%s,"machine":{"load":%s,"cores":%s,"load_warn":%s},"paths":{"base":"%s","log":"%s","log_dir":"%s","telemetry":"%s"},"pools":[' \
+  printf '{"paused":%s,"local":%s,"machine":{"load":%s,"cores":%s,"load_warn":%s},"paths":{"base":"%s","cache":"%s","log":"%s","log_dir":"%s","telemetry":"%s"},"pools":[' \
     "${paused}" "$( [ "${local_only}" = "1" ] && echo true || echo false )" \
     "${load:-0}" "${cores:-0}" "${RUNPOOL_LOAD_WARN}" \
-    "${RUNPOOL_BASE}" "${RUNPOOL_LOG}" "${RUNPOOL_LOG_DIR}" "${RUNPOOL_BASE}/telemetry/jobs.jsonl"
+    "${RUNPOOL_BASE}" "${RUNPOOL_CACHE_DIR}" "${RUNPOOL_LOG}" "${RUNPOOL_LOG_DIR}" "${RUNPOOL_BASE}/telemetry/jobs.jsonl"
   for p in $(_rp_pool_names); do
     _rp_load_pool "${p}" || continue
     running="$(_rp_running_in "${p}" "${POOL_COUNT}")"
@@ -147,8 +148,9 @@ _rp_status_json() {
     fi
     [ "${first}" = "1" ] || printf ','
     first=0
-    printf '{"name":"%s","scope":"%s","target":"%s","count":%s,"running":%s,"busy":%s,"github_registered":%s,"github_online":%s,"watch":[' \
-      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${POOL_COUNT}" "${running}" "${busy}" "${reg}" "${online}"
+    _rp_pool_paused "${p}" && pool_paused="true" || pool_paused="false"
+    printf '{"name":"%s","scope":"%s","target":"%s","count":%s,"running":%s,"busy":%s,"paused":%s,"github_registered":%s,"github_online":%s,"watch":[' \
+      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${POOL_COUNT}" "${running}" "${busy}" "${pool_paused}" "${reg}" "${online}"
     # An org pool serves many repositories and only its config knows which.
     # Without this a caller cannot show what a pool actually covers.
     wfirst=1
@@ -220,7 +222,7 @@ _rp_doctor() {
   [ $# -eq 0 ] || { _rp_err "doctor takes no arguments (usage: runpool doctor)"; return 1; }
 
   local gh_ok=1 pools=0 seen_orgs="" p running gh reg online
-  local tick clean i missing avail_kb free mode other
+  local tick clean i missing avail_kb cache_avail_kb free mode other
 
   _rp_doctor_fails=0
   _rp_doctor_warns=0
@@ -236,6 +238,8 @@ _rp_doctor() {
   else
     _rp_doctor_ok "not paused"
   fi
+  [ "${RUNPOOL_USING_LEGACY}" = "1" ] && _rp_doctor_note \
+    "legacy storage is active at ${RUNPOOL_BASE}; run 'runpool migrate-storage --dry-run' to preview the move"
 
   # --- gh ----------------------------------------------------------------
   # _rp_require tests for the binary and stops there, which is the whole gap:
@@ -298,6 +302,8 @@ _rp_doctor() {
       continue
     fi
     running="$(_rp_running_in "${p}" "${POOL_COUNT}")"
+    _rp_pool_paused "${p}" && _rp_doctor_note \
+      "${p}: paused; it will not autoscale or start until 'runpool resume ${p}'"
 
     # A pool is meant to sit down, so 'not loaded' says nothing and is not
     # reported. A MISSING plist is different: _rp_up refuses on the first one
@@ -381,6 +387,17 @@ _rp_doctor() {
         _rp_doctor_ok "${free} free on ${RUNPOOL_BASE}"
       fi ;;
   esac
+  cache_avail_kb=$(df -k "${RUNPOOL_CACHE_DIR}" 2>/dev/null | awk 'NR == 2 {print $4}')
+  case "${cache_avail_kb}" in
+    ''|*[!0-9]*) _rp_doctor_note "could not read the free space on ${RUNPOOL_CACHE_DIR}" ;;
+    *)
+      if [ "${cache_avail_kb}" -lt 1048576 ]; then
+        free="$(( cache_avail_kb / 1024 ))MB"
+      else
+        free="$(( cache_avail_kb / 1048576 ))GB"
+      fi
+      _rp_doctor_ok "${free} free on cache root ${RUNPOOL_CACHE_DIR}" ;;
+  esac
 
   # --- security -----------------------------------------------------------
   echo ""
@@ -463,6 +480,7 @@ _rp_autoscale() {
   local p up queued q wr
   for p in $(_rp_pool_names); do
     _rp_load_pool "${p}" || continue
+    _rp_pool_paused "${p}" && continue
     up="$(_rp_running_in "${p}" "${POOL_COUNT}")"
     [ "${up}" -gt 0 ] && continue
     queued=0
@@ -515,7 +533,7 @@ _rp_clean() {
   # Every local declared once, at the top. Re-running 'local' for an existing
   # local inside a loop makes some shells print it as a typeset assignment,
   # which once leaked stray lines into the nightly log.
-  local only="${1:-}" p freed_kb=0 sz rd wd dd td live keep vols nvols ntmp utmp
+  local only="${1:-}" p freed_kb=0 sz rd wd dd td i cache_dir pnpm_dir live keep vols nvols ntmp utmp
   for p in $(_rp_pool_names); do
     [ -n "${only}" ] && [ "${only}" != "${p}" ] && continue
     _rp_load_pool "${p}" || continue
@@ -528,9 +546,11 @@ _rp_clean() {
     for rd in "${POOL_DIR}"/runner-*/; do
       [ -d "${rd}" ] || continue
       rd="${rd%/}"
+      i="${rd##*/runner-}"
+      cache_dir="$(_rp_runner_cache_dir "${p}" "${i}")"
 
       # Job checkouts and build output.
-      wd="${rd}/_work"
+      wd="$(_rp_runner_work_dir "${p}" "${i}")"
       if [ -d "${wd}" ]; then
         sz=$(du -sk "${wd}" 2>/dev/null | awk '{print $1}')
         find "${wd:?}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null
@@ -544,7 +564,12 @@ _rp_clean() {
       # component in the absolute path silently disables anything applying
       # dotfile-ignore rules to it. An install predating the rename still holds
       # the old directory, which would otherwise sit uncollected forever.
-      for td in "${rd}/tmp" "${rd}/.tmp"; do
+      if [ "${POOL_LEGACY_LAYOUT}" = "1" ]; then
+        td="${rd}/.tmp"
+      else
+        td=""
+      fi
+      for td in "${cache_dir}/tmp" "${td}"; do
         if [ -d "${td}" ]; then
           sz=$(du -sk "${td}" 2>/dev/null | awk '{print $1}')
           find "${td:?}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null
@@ -552,8 +577,12 @@ _rp_clean() {
         fi
       done
       # The legacy directory goes for good once emptied; the current one stays.
-      rmdir "${rd}/.tmp" 2>/dev/null
-      mkdir -p "${rd}/tmp" 2>/dev/null
+      if [ "${POOL_LEGACY_LAYOUT}" = "1" ]; then
+        rmdir "${rd}/.tmp" 2>/dev/null
+        mkdir -p "${rd}/tmp" 2>/dev/null
+      else
+        mkdir -p "${cache_dir}/tmp" 2>/dev/null
+      fi
 
       # Runner diagnostics. Rotated loosely and reaching ~150MB per runner. Job
       # logs live in the GitHub UI, so nothing here is the only copy.
@@ -581,10 +610,11 @@ _rp_clean() {
 
       # Package stores are a cache worth keeping but an unbounded one. Prune
       # rather than delete, so the next run starts warm.
-      if [ -d "${rd}/.pnpm-store" ] && command -v pnpm >/dev/null 2>&1; then
-        sz=$(du -sk "${rd}/.pnpm-store" 2>/dev/null | awk '{print $1}')
-        npm_config_store_dir="${rd}/.pnpm-store" pnpm store prune >/dev/null 2>&1
-        freed_kb=$(( freed_kb + sz - $(du -sk "${rd}/.pnpm-store" 2>/dev/null | awk '{print $1}') ))
+      if [ "${POOL_LEGACY_LAYOUT}" = "1" ]; then pnpm_dir="${rd}/.pnpm-store"; else pnpm_dir="${cache_dir}/pnpm"; fi
+      if [ -d "${pnpm_dir}" ] && command -v pnpm >/dev/null 2>&1; then
+        sz=$(du -sk "${pnpm_dir}" 2>/dev/null | awk '{print $1}')
+        npm_config_store_dir="${pnpm_dir}" pnpm store prune >/dev/null 2>&1
+        freed_kb=$(( freed_kb + sz - $(du -sk "${pnpm_dir}" 2>/dev/null | awk '{print $1}') ))
       fi
     done
   done
@@ -690,8 +720,38 @@ _rp_tick() {
 # ---------------------------------------------------------------------------
 # pause / resume — global kill switch, default resumed
 # ---------------------------------------------------------------------------
-_rp_pause()  { : >| "${RUNPOOL_PAUSE_FLAG}"; _rp_down_all --force; _rp_log "Paused: all runners stopped; autoscaling disabled."; }
-_rp_resume() { rm -f "${RUNPOOL_PAUSE_FLAG}"; _rp_log "Resumed: on-demand scaling enabled."; }
+_rp_pause() {
+  local name="${1:-}" busy
+  if [ -z "${name}" ]; then
+    : >| "${RUNPOOL_PAUSE_FLAG}"
+    _rp_down_all --force
+    _rp_log "Paused: all runners stopped; autoscaling disabled."
+    return 0
+  fi
+  _rp_load_pool "${name}" || return 1
+  _rp_pool_paused "${name}" && { _rp_log "Pool '${name}' is already paused."; return 0; }
+  busy="$(_rp_busy_in "${POOL_DIR}")"
+  if [ "${busy}" -gt 0 ]; then
+    _rp_err "'${name}' has ${busy} job(s) running — refusing to pause. Wait for them to finish, then retry."
+    return 1
+  fi
+  : >| "$(_rp_pool_pause_flag "${name}")"
+  _rp_down "${name}" || { rm -f "$(_rp_pool_pause_flag "${name}")"; return 1; }
+  _rp_log "Paused pool '${name}'. It will not start until resumed."
+}
+
+_rp_resume() {
+  local name="${1:-}"
+  if [ -z "${name}" ]; then
+    rm -f "${RUNPOOL_PAUSE_FLAG}"
+    _rp_log "Resumed: on-demand scaling enabled."
+    return 0
+  fi
+  _rp_load_pool "${name}" || return 1
+  _rp_pool_paused "${name}" || { _rp_log "Pool '${name}' is not paused."; return 0; }
+  rm -f "$(_rp_pool_pause_flag "${name}")"
+  _rp_log "Resumed pool '${name}'. It will wake when work is queued."
+}
 
 # ---------------------------------------------------------------------------
 # schedule — install or remove the background agents

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -59,7 +59,7 @@ _rp_running_in() {
 # cleanly, looks healthy in every local check, and picks up nothing. Reporting
 # only the local view hid exactly that for three weeks.
 _rp_status() {
-  local as_json=0 local_only=0 arg
+  local as_json=0 local_only=0 arg total_running=0 total_busy=0 p running busy gh reg online gh_display note warn=0
   for arg in "$@"; do
     case "${arg}" in
       --json)  as_json=1 ;;
@@ -69,31 +69,42 @@ _rp_status() {
   done
   [ "${as_json}" = "1" ] && { _rp_status_json "${local_only}"; return $?; }
 
-  if _rp_paused; then echo "GLOBAL: paused (runpool off)"; else echo "GLOBAL: active"; fi
-  local total_running=0 total_busy=0 p running busy gh reg online note warn=0
+  if _rp_paused; then echo "Status: paused"; else echo "Status: active"; fi
+  echo ""
+  printf "  %-10s %-6s %-20s %7s %5s  %s\n" "Pool" "Scope" "Target" "Running" "Busy" "GitHub"
   for p in $(_rp_pool_names); do
     _rp_load_pool "${p}" || continue
     running="$(_rp_running_in "${p}" "${POOL_COUNT}")"
     busy="$(_rp_busy_in "${POOL_DIR}")"
-    gh="$(_rp_gh_runners)"; reg="${gh% *}"; online="${gh#* }"
     total_running=$(( total_running + running )); total_busy=$(( total_busy + busy ))
 
-    note=""
-    case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}")" in
-      unreachable)  note="  (github unreachable)" ;;
-      unregistered) note="  ** NOT REGISTERED — jobs will queue forever **"; warn=1 ;;
-      offline)      note="  ** started but not connecting to github **"; warn=1 ;;
-      miscount)     note="  (github has ${reg}, pool expects ${POOL_COUNT})" ;;
-    esac
+    if [ "${local_only}" = "1" ]; then
+      gh_display="not checked"
+      note=""
+    else
+      gh="$(_rp_gh_runners)"; reg="${gh% *}"; online="${gh#* }"
+      gh_display="${online}/${reg}"
+      note=""
+      case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}")" in
+        unreachable)  gh_display="unreachable" ;;
+        unregistered) note="  (not registered; jobs will queue)"; warn=1 ;;
+        offline)      note="  (started but not connected)"; warn=1 ;;
+        miscount)     note="  (pool expects ${POOL_COUNT})" ;;
+      esac
+    fi
 
-    printf "  %-10s %-4s %-20s  running %s/%s  busy %s  github %s/%s%s\n" \
-      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${running}" "${POOL_COUNT}" \
-      "${busy}" "${online}" "${reg}" "${note}"
+    printf "  %-10s %-6s %-20s %7s %5s  %s%s\n" \
+      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${running}/${POOL_COUNT}" \
+      "${busy}" "${gh_display}" "${note}"
   done
-  echo "  ----"
-  echo "  TOTAL running ${total_running}, busy ${total_busy}"
-  echo "  github column is online/registered as GitHub sees it"
-  [ "${warn}" = "1" ] && echo "  fix a broken pool with: runpool reregister <pool>"
+  echo ""
+  echo "Total: ${total_running} runners online, ${total_busy} jobs running."
+  if [ "${local_only}" = "1" ]; then
+    echo "GitHub: not checked (--local)."
+  else
+    echo "GitHub: online / registered."
+  fi
+  [ "${warn}" = "1" ] && echo "Fix a broken pool with: runpool reregister <pool>"
   return 0
 }
 
@@ -679,8 +690,8 @@ _rp_tick() {
 # ---------------------------------------------------------------------------
 # pause / resume — global kill switch, default resumed
 # ---------------------------------------------------------------------------
-_rp_pause()  { : >| "${RUNPOOL_PAUSE_FLAG}"; _rp_down_all --force; _rp_log "paused: all runners down, autoscale off"; }
-_rp_resume() { rm -f "${RUNPOOL_PAUSE_FLAG}"; _rp_log "resumed: on-demand again"; }
+_rp_pause()  { : >| "${RUNPOOL_PAUSE_FLAG}"; _rp_down_all --force; _rp_log "Paused: all runners stopped; autoscaling disabled."; }
+_rp_resume() { rm -f "${RUNPOOL_PAUSE_FLAG}"; _rp_log "Resumed: on-demand scaling enabled."; }
 
 # ---------------------------------------------------------------------------
 # schedule — install or remove the background agents

--- a/runpool.conf.example
+++ b/runpool.conf.example
@@ -8,10 +8,14 @@
 # umask would otherwise leave this readable by every user on the machine:
 #   chmod 600 ~/.config/runpool/config
 
-# Where runners, pool definitions, launch agents and state live.
-# Defaults to ~/.local/share/runpool. Registration credentials live here, so
-# keep it off any synced or shared volume.
-# RUNPOOL_BASE="${HOME}/.local/share/runpool"
+# Required state: runner installations and credentials, pool definitions,
+# pause state and generated launch agents. Defaults to macOS Application
+# Support. Keep it off any synced or shared volume.
+# RUNPOOL_BASE="${HOME}/Library/Application Support/runpool"
+
+# Regenerable data: job work trees, downloaded actions and tools, per-runner
+# package caches, temp directories and runner archives. Defaults to Caches.
+# RUNPOOL_CACHE_DIR="${HOME}/Library/Caches/runpool"
 
 # The pools `runpool apply` reconciles this machine to. Defaults to
 # ~/.config/runpool/pools; see runpool.pools.example. Unlike everything else

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -20,6 +20,7 @@ On-demand self-hosted GitHub Actions runner pools for macOS. Pools wake when job
 command -v runpool || echo "not installed"
 runpool status
 runpool doctor    # if anything looks wrong, or a job is queued and waiting
+runpool help <command>  # command-specific options and guidance
 ```
 
 Not installed:

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -47,6 +47,8 @@ runpool schedule install                             # once per machine
 
 **An org pool needs `--watch` or it never autoscales.** See *`--watch` is org-only and matters* below. A repo pool polls its own target and refuses the flag.
 
+**Pause is persistent when scoped to a pool.** `runpool pause <pool>` safely stands that pool down and prevents either autoscale or `runpool up <pool>` from starting it. Use `runpool resume <pool>` to clear it. Bare `pause` and `resume` remain the global controls; `down <pool>` is only a temporary stand-down.
+
 **Adding several pools, or setting up a second machine?** Describe them in a file and reconcile to it instead — see *Declaring a machine's pools* below.
 
 **2. Routing.** In the workflow, route the job:
@@ -152,6 +154,21 @@ tail -50 ~/Library/Logs/runpool/runpool.log
 ```
 
 The JSON carries each pool's watched repositories and the paths to its logs, so a wrapper never has to guess either.
+
+**The root `paused` field is global; each pool has its own `paused` boolean.** Read both. A paused pool is intentional state, not an unreachable runner.
+
+## Storage migration
+
+New installations keep runner credentials, pool definitions and pause state in `~/Library/Application Support/runpool`, with work trees and per-runner caches in `~/Library/Caches/runpool`. Existing `RUNPOOL_BASE` installations remain active until explicitly migrated.
+
+```bash
+runpool migrate-storage --dry-run
+runpool migrate-storage
+runpool status --local
+runpool doctor
+```
+
+**Do not run migration while a job is active.** RunPool refuses it, preserving registrations and the legacy tree. The old tree is retained after migration; remove it only after verification with `runpool migrate-storage --remove-legacy`. For a custom legacy `RUNPOOL_BASE`, use the exact `--from` and `--to` command printed by migration.
 
 ## Capacity
 

--- a/tests/storage-migration.sh
+++ b/tests/storage-migration.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Run against a scratch installation only. This verifies the storage migration
+# without registering a runner or calling GitHub.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+legacy_dir="${scratch_dir}/legacy"
+support_dir="${scratch_dir}/Application Support/runpool"
+cache_dir="${scratch_dir}/Caches/runpool"
+config_dir="${scratch_dir}/config"
+log_dir="${scratch_dir}/logs"
+
+cleanup() { rm -rf "${scratch_dir}"; }
+trap cleanup EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_file() { [ -f "$1" ] || fail "missing file: $1"; }
+assert_dir() { [ -d "$1" ] || fail "missing directory: $1"; }
+assert_contains() { grep -F "$2" "$1" >/dev/null || fail "${1} does not contain ${2}"; }
+
+mkdir -p "${legacy_dir}/pools" "${legacy_dir}/agents" "${legacy_dir}/state/pools" \
+         "${legacy_dir}/alpha/runner-1/_work/repository" \
+         "${legacy_dir}/alpha/runner-1/.pnpm-store" \
+         "${legacy_dir}/alpha/runner-1/.npm-cache" \
+         "${legacy_dir}/alpha/runner-1/tmp" "${config_dir}" "${log_dir}"
+
+cat >| "${legacy_dir}/pools/alpha.conf" <<CONF
+POOL_NAME="alpha"
+POOL_SCOPE="repo"
+POOL_TARGET="acme/example"
+POOL_COUNT="1"
+POOL_DIR="${legacy_dir}/alpha"
+POOL_LABELS="self-hosted,macOS,ARM64,alpha"
+CONF
+printf 'RUNPOOL_BASE="%s"\n' "${legacy_dir}" >| "${config_dir}/runpool.conf"
+chmod 600 "${config_dir}/runpool.conf"
+cat >| "${legacy_dir}/alpha/runner-1/.runner" <<RUNNER
+{"agentId":1,"workFolder":"_work"}
+RUNNER
+touch "${legacy_dir}/alpha/runner-1/run.sh" \
+      "${legacy_dir}/alpha/runner-1/_work/repository/file" \
+      "${legacy_dir}/alpha/runner-1/.pnpm-store/file" \
+      "${legacy_dir}/alpha/runner-1/.npm-cache/file" \
+      "${legacy_dir}/alpha/runner-1/tmp/file" \
+      "${legacy_dir}/state/pools/alpha.paused"
+
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" migrate-storage --dry-run --from "${legacy_dir}" --to "${support_dir}" \
+    >/dev/null || fail "dry run failed"
+[ ! -f "${support_dir}/pools/alpha.conf" ] || fail "dry run changed the target"
+
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" migrate-storage --from "${legacy_dir}" --to "${support_dir}" \
+    >/dev/null || fail "migration failed"
+
+assert_file "${legacy_dir}/pools/alpha.conf"
+assert_file "${support_dir}/pools/alpha.conf"
+assert_contains "${config_dir}/runpool.conf" "RUNPOOL_BASE=\"${support_dir}\""
+[ "$(stat -f '%Lp' "${config_dir}/runpool.conf")" = "600" ] || fail "config mode changed"
+assert_contains "${support_dir}/pools/alpha.conf" "POOL_DIR=\"${support_dir}/runners/alpha\""
+assert_contains "${support_dir}/pools/alpha.conf" "POOL_CACHE_DIR=\"${cache_dir}/pools/alpha\""
+assert_file "${support_dir}/runners/alpha/runner-1/.runner"
+assert_contains "${support_dir}/runners/alpha/runner-1/.runner" "\"workFolder\":\"${cache_dir}/pools/alpha/runner-1/work\""
+assert_file "${cache_dir}/pools/alpha/runner-1/work/repository/file"
+assert_file "${cache_dir}/pools/alpha/runner-1/pnpm/file"
+assert_file "${cache_dir}/pools/alpha/runner-1/npm/file"
+assert_file "${cache_dir}/pools/alpha/runner-1/tmp/file"
+assert_file "${support_dir}/agents/runpool.alpha.1.plist"
+assert_contains "${support_dir}/agents/runpool.alpha.1.plist" "${cache_dir}/pools/alpha/runner-1/pnpm"
+
+status_file="${scratch_dir}/status.json"
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" status --json --local >| "${status_file}" || fail "status failed"
+assert_contains "${status_file}" "\"cache\":\"${cache_dir}\""
+assert_contains "${status_file}" "\"paused\":true"
+
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" up alpha >/dev/null 2>&1 && fail "paused pool started"
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" resume alpha >/dev/null || fail "pool resume failed"
+[ ! -f "${support_dir}/state/pools/alpha.paused" ] || fail "pool pause flag remained"
+
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" pause alpha >/dev/null || fail "pool pause failed"
+assert_file "${support_dir}/state/pools/alpha.paused"
+
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" migrate-storage --from "${legacy_dir}" --to "${support_dir}" --remove-legacy \
+    >/dev/null || fail "legacy removal failed"
+[ ! -e "${legacy_dir}" ] || fail "legacy installation remained"
+
+# An empty native root must not make an existing XDG installation invisible.
+# This is the compatibility path a user takes simply by installing the new
+# binary; no migration has happened yet and their runner registrations remain
+# the active installation.
+fallback_home="${scratch_dir}/fallback-home"
+fallback_legacy="${fallback_home}/.local/share/runpool"
+fallback_support="${fallback_home}/Library/Application Support/runpool"
+fallback_cache="${fallback_home}/Library/Caches/runpool"
+fallback_log="${fallback_home}/Library/Logs/runpool"
+mkdir -p "${fallback_legacy}/pools" "${fallback_support}"
+cat >| "${fallback_legacy}/pools/beta.conf" <<CONF
+POOL_NAME="beta"
+POOL_SCOPE="repo"
+POOL_TARGET="acme/example"
+POOL_COUNT="1"
+POOL_DIR="${fallback_legacy}/beta"
+POOL_LABELS="self-hosted,macOS,ARM64,beta"
+CONF
+fallback_status="${scratch_dir}/fallback-status.json"
+env HOME="${fallback_home}" RUNPOOL_CONFIG=/dev/null RUNPOOL_POOLS_FILE="${scratch_dir}/fallback-pools" \
+    RUNPOOL_CACHE_DIR="${fallback_cache}" RUNPOOL_LOG_DIR="${fallback_log}" RUNPOOL_LOG="${fallback_log}/runpool.log" \
+    "${repo_dir}/bin/runpool" status --json --local >| "${fallback_status}" || fail "legacy fallback status failed"
+assert_contains "${fallback_status}" "\"base\":\"${fallback_legacy}\""
+
+echo "ok storage migration"


### PR DESCRIPTION
## Summary

- store durable runner state in Application Support and regenerable data in Caches
- add a safe, tested migration command that retains legacy state until explicit removal
- add persistent per-pool pause state to CLI, status JSON, documentation and the demo fixture

## Validation

- `/bin/bash -n bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh`
- `shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh`
- `tests/storage-migration.sh`

Fixes #40