### PR TITLE
fix: make native storage migration self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The file holds no credentials and nothing machine-specific, so **a second machin
 
 ## Storage and migration
 
-**Required state lives in `~/Library/Application Support/runpool`.** That includes runner installations and credentials, pool definitions, pause state, generated launch agents and telemetry. **Regenerable data lives in `~/Library/Caches/runpool`**: job work trees, checked-out repositories, downloaded actions and tools, package stores, temp directories and runner downloads. Logs remain in `~/Library/Logs/runpool`; the config and pools file remain under `~/.config/runpool`.
+**Required state lives in `~/Library/Application Support/runpool`.** That includes runner installations and credentials, pool definitions, pause state, generated launch agents and telemetry. **Regenerable data lives in `~/Library/Caches/runpool`**: job work trees, checked-out repositories, downloaded actions and tools, package stores, temp directories and runner downloads. Logs remain in `~/Library/Logs/runpool`; the config, pools file and generated job-hook launchers remain under `~/.config/runpool`. The launchers deliberately stay there because GitHub's runner requires an absolute hook path but does not quote Bash hook paths containing whitespace.
 
 `RUNPOOL_BASE`, `RUNPOOL_CACHE_DIR` and `RUNPOOL_LOG_DIR` can override those roots, with the usual precedence: environment, config file, then default. Existing `RUNPOOL_BASE` installations remain active until migrated, so upgrading never silently strands registrations.
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -26,6 +26,7 @@ _rp_env_IDLE_SECS="${RUNPOOL_IDLE_SECS:-}"
 _rp_env_LOAD_WARN="${RUNPOOL_LOAD_WARN:-}"
 _rp_env_NOTIFY_CMD="${RUNPOOL_NOTIFY_CMD:-}"
 _rp_env_JOB_HOOK="${RUNPOOL_JOB_HOOK:-}"
+_rp_env_HOOK_DIR="${RUNPOOL_HOOK_DIR:-}"
 _rp_env_TELEMETRY="${RUNPOOL_TELEMETRY:-}"
 
 # 'set -a' exports everything the config assigns, which matters because a
@@ -47,15 +48,16 @@ set +a
 [ -n "${_rp_env_LOAD_WARN}" ]   && RUNPOOL_LOAD_WARN="${_rp_env_LOAD_WARN}"
 [ -n "${_rp_env_NOTIFY_CMD}" ]  && RUNPOOL_NOTIFY_CMD="${_rp_env_NOTIFY_CMD}"
 [ -n "${_rp_env_JOB_HOOK}" ]    && RUNPOOL_JOB_HOOK="${_rp_env_JOB_HOOK}"
+[ -n "${_rp_env_HOOK_DIR}" ]    && RUNPOOL_HOOK_DIR="${_rp_env_HOOK_DIR}"
 [ -n "${_rp_env_TELEMETRY}" ]   && RUNPOOL_TELEMETRY="${_rp_env_TELEMETRY}"
 unset _rp_env_BASE _rp_env_CACHE_DIR _rp_env_POOLS_FILE _rp_env_LOG_DIR _rp_env_LABEL_NS \
       _rp_env_IDLE_SECS _rp_env_LOAD_WARN _rp_env_NOTIFY_CMD _rp_env_JOB_HOOK \
-      _rp_env_TELEMETRY
+      _rp_env_HOOK_DIR _rp_env_TELEMETRY
 
 # Restored values need exporting again: the restore above is a plain assignment
 # and happens after 'set -a' was turned off.
 export RUNPOOL_BASE RUNPOOL_CACHE_DIR RUNPOOL_LOG_DIR RUNPOOL_LABEL_NS RUNPOOL_IDLE_SECS \
-       RUNPOOL_LOAD_WARN RUNPOOL_NOTIFY_CMD RUNPOOL_JOB_HOOK RUNPOOL_TELEMETRY \
+       RUNPOOL_LOAD_WARN RUNPOOL_NOTIFY_CMD RUNPOOL_JOB_HOOK RUNPOOL_HOOK_DIR RUNPOOL_TELEMETRY \
        RUNPOOL_CONFIG RUNPOOL_POOLS_FILE
 
 # Required state belongs in Application Support. Runner installations carry
@@ -91,6 +93,13 @@ RUNPOOL_RUNNER_DIR="${RUNPOOL_BASE}/runners"
 RUNPOOL_AGENT_DIR="${RUNPOOL_BASE}/agents"
 RUNPOOL_STATE_DIR="${RUNPOOL_BASE}/state"
 RUNPOOL_LOG_DIR="${RUNPOOL_LOG_DIR:-${HOME}/Library/Logs/runpool}"
+
+# GitHub's runner passes a Bash hook path without quoting it, so a wrapper
+# below "Application Support" fails before the workflow starts. These tiny
+# launchers are durable configuration, not cache data: Caches can be evicted
+# while a listener is online. Keep them beside the operator-owned config and
+# validate the runner's stricter path contract before writing an agent.
+RUNPOOL_HOOK_DIR="${RUNPOOL_HOOK_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpool/hooks}"
 
 RUNPOOL_LOG="${RUNPOOL_LOG_DIR}/runpool.log"
 RUNPOOL_ACTIVITY="${RUNPOOL_STATE_DIR}/activity"
@@ -428,15 +437,37 @@ _rp_deregister_runner() {
 # is installation-specific.
 _rp_write_hook_wrappers() {
   [ -n "${RUNPOOL_JOB_HOOK:-}" ] || return 0
-  local dir="${RUNPOOL_BASE}/hooks" phase
-  mkdir -p "${dir}" 2>/dev/null
+  local dir="${RUNPOOL_HOOK_DIR}" phase old_dir="${RUNPOOL_BASE}/hooks"
+  case "${RUNPOOL_JOB_HOOK}" in
+    /*) ;;
+    *) _rp_err "RUNPOOL_JOB_HOOK must be an absolute path: ${RUNPOOL_JOB_HOOK}"; return 1 ;;
+  esac
+  [ -x "${RUNPOOL_JOB_HOOK}" ] || {
+    _rp_err "RUNPOOL_JOB_HOOK is not executable: ${RUNPOOL_JOB_HOOK}"
+    return 1
+  }
+  case "${dir}" in
+    /*) ;;
+    *) _rp_err "RUNPOOL_HOOK_DIR must be an absolute path: ${dir}"; return 1 ;;
+  esac
+  case "${dir}" in
+    *[[:space:]]*)
+      _rp_err "RUNPOOL_HOOK_DIR cannot contain whitespace because the GitHub Actions runner does not quote Bash hook paths: ${dir}"
+      return 1
+      ;;
+  esac
+  mkdir -p "${dir}" 2>/dev/null || { _rp_err "could not create hook directory: ${dir}"; return 1; }
   for phase in started completed; do
     cat >| "${dir}/${phase}.sh" <<WRAP
 #!/bin/sh
 exec "${RUNPOOL_JOB_HOOK}" ${phase}
 WRAP
-    chmod +x "${dir}/${phase}.sh" 2>/dev/null
+    chmod +x "${dir}/${phase}.sh" 2>/dev/null || return 1
   done
+  if [ "${old_dir}" != "${dir}" ]; then
+    rm -f "${old_dir}/started.sh" "${old_dir}/completed.sh" 2>/dev/null || true
+    rmdir "${old_dir}" 2>/dev/null || true
+  fi
 }
 
 # Write the on-demand launch agent for one runner. $1 label, $2 runner_dir.
@@ -455,7 +486,10 @@ _rp_write_plist() {
     npm_dir="${cache_dir}/npm"
     tmp_dir="${cache_dir}/tmp"
   fi
-  [ -n "${RUNPOOL_JOB_HOOK:-}" ] && { _rp_write_hook_wrappers; hook="${RUNPOOL_BASE}/hooks"; }
+  if [ -n "${RUNPOOL_JOB_HOOK:-}" ]; then
+    _rp_write_hook_wrappers || return 1
+    hook="${RUNPOOL_HOOK_DIR}"
+  fi
   {
     cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -533,7 +567,7 @@ _rp_rewrite_plists() {
     while [ "${i}" -le "${POOL_COUNT}" ]; do
       _rp_prepare_runner_cache "${p}" "${i}"
       _rp_write_plist "$(_rp_label "${p}" "${i}")" "${POOL_DIR}/runner-${i}" \
-                      "$(_rp_runner_cache_dir "${p}" "${i}")" "${POOL_LEGACY_LAYOUT}"
+                      "$(_rp_runner_cache_dir "${p}" "${i}")" "${POOL_LEGACY_LAYOUT}" || return 1
       i=$(( i + 1 ))
     done
     _rp_log "rewrote agents for pool '${p}'"

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -532,7 +532,7 @@ _rp_migrate_storage() {
   done
 
   mkdir -p "${target}/pools" "${target}/runners" "${target}/agents" "${target}/state" \
-           "${target}/state/pools" "${target}/hooks" "${target}/telemetry" \
+           "${target}/state/pools" "${target}/telemetry" \
            "${RUNPOOL_CACHE_DIR}/downloads" || return 1
   for p in $(_rp_migrate_pool_names "${source}"); do
     conf="${source}/pools/${p}.conf"
@@ -565,7 +565,7 @@ _rp_migrate_storage() {
     done
     _rp_migrate_update_pool_conf "${target}/pools/${p}.conf" "${new_dir}" "${cache_pool}" || return 1
   done
-  for arg in agents state hooks telemetry; do
+  for arg in agents state telemetry; do
     if [ -d "${source}/${arg}" ]; then
       cp -R "${source}/${arg}/." "${target}/${arg}/" || return 1
     fi
@@ -603,6 +603,7 @@ _rp_up() {
   if _rp_paused; then _rp_err "runpool is paused — run 'runpool resume' first"; return 1; fi
   if _rp_pool_paused "$1"; then _rp_err "pool '$1' is paused — run 'runpool resume $1' first"; return 1; fi
   local i label plist loaded=0
+  [ -z "${RUNPOOL_JOB_HOOK:-}" ] || _rp_write_hook_wrappers || return 1
   i=1
   while [ "${i}" -le "${POOL_COUNT}" ]; do
     label="$(_rp_label "$1" "${i}")"

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -423,6 +423,24 @@ _rp_migrate_move_cache_dir() {
   mv "${from}" "${to}"
 }
 
+_rp_migrate_rewrite_runner_links() {
+  local runner_dir="$1" name link target target_name
+  for name in bin externals; do
+    link="${runner_dir}/${name}"
+    [ -L "${link}" ] || continue
+    target=$(readlink "${link}") || return 1
+    target_name="${target##*/}"
+    [ -n "${target_name}" ] && [ -d "${runner_dir}/${target_name}" ] || {
+      _rp_err "migration copied an unresolved runner link: ${link} -> ${target}"
+      return 1
+    }
+    # GitHub's runner updater creates absolute links to its versioned bin and
+    # externals directories. Make the copied installation self-contained so
+    # removing the legacy tree cannot break Runner.Listener afterwards.
+    ln -sfn "${target_name}" "${link}" || return 1
+  done
+}
+
 _rp_migrate_storage() {
   local dry=0 remove_legacy=0 source="" target="" active_base="${RUNPOOL_BASE}" arg p conf old_dir new_dir cache_pool i runner_dir cache_dir busy=0
   while [ $# -gt 0 ]; do
@@ -531,6 +549,7 @@ _rp_migrate_storage() {
     while [ "${i}" -le "${POOL_COUNT}" ]; do
       runner_dir="${new_dir}/runner-${i}"
       cache_dir="${cache_pool}/runner-${i}"
+      _rp_migrate_rewrite_runner_links "${runner_dir}" || return 1
       mkdir -p "${cache_dir}" || return 1
       _rp_migrate_move_cache_dir "${runner_dir}/_work" "${cache_dir}/work" || return 1
       _rp_migrate_move_cache_dir "${runner_dir}/.pnpm-store" "${cache_dir}/pnpm" || return 1

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -222,7 +222,7 @@ _rp_doctor() {
   [ $# -eq 0 ] || { _rp_err "doctor takes no arguments (usage: runpool doctor)"; return 1; }
 
   local gh_ok=1 pools=0 seen_orgs="" p running gh reg online
-  local tick clean i missing avail_kb cache_avail_kb free mode other
+  local tick clean i missing avail_kb cache_avail_kb free mode other phase hook_fails
 
   _rp_doctor_fails=0
   _rp_doctor_warns=0
@@ -285,6 +285,36 @@ _rp_doctor() {
   else
     _rp_doctor_warn "the clean agent is not loaded, so work directories, diagnostics and superseded runner binaries accrue with nothing collecting them" \
                     "fix: runpool schedule install, or 'runpool clean' by hand"
+  fi
+
+  # --- job hooks ---------------------------------------------------------
+  echo ""
+  echo "job hooks"
+  if [ -z "${RUNPOOL_JOB_HOOK:-}" ]; then
+    _rp_doctor_note "no job hook is configured"
+  else
+    hook_fails="${_rp_doctor_fails}"
+    case "${RUNPOOL_HOOK_DIR}" in
+      /*) ;;
+      *) _rp_doctor_fail "the hook launcher directory is not absolute: ${RUNPOOL_HOOK_DIR}" \
+                         "fix: set RUNPOOL_HOOK_DIR to an absolute path without whitespace, then runpool rewrite-agents" ;;
+    esac
+    case "${RUNPOOL_HOOK_DIR}" in
+      *[[:space:]]*)
+        _rp_doctor_fail "the hook launcher directory contains whitespace, which the GitHub Actions runner does not quote: ${RUNPOOL_HOOK_DIR}" \
+                        "fix: remove RUNPOOL_HOOK_DIR from the config to use the safe default, then runpool rewrite-agents"
+        ;;
+    esac
+    if [ ! -x "${RUNPOOL_JOB_HOOK}" ]; then
+      _rp_doctor_fail "the configured job hook is not executable: ${RUNPOOL_JOB_HOOK}" \
+                      "fix: correct RUNPOOL_JOB_HOOK or make it executable, then runpool rewrite-agents"
+    fi
+    for phase in started completed; do
+      [ -x "${RUNPOOL_HOOK_DIR}/${phase}.sh" ] || _rp_doctor_fail \
+        "the ${phase} job-hook launcher is missing or not executable: ${RUNPOOL_HOOK_DIR}/${phase}.sh" \
+        "fix: runpool rewrite-agents"
+    done
+    [ "${_rp_doctor_fails}" = "${hook_fails}" ] && _rp_doctor_ok "job-hook launchers are executable at a runner-safe path"
   fi
 
   # --- pools --------------------------------------------------------------

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -159,7 +159,7 @@ The JSON carries each pool's watched repositories and the paths to its logs, so 
 
 ## Storage migration
 
-New installations keep runner credentials, pool definitions and pause state in `~/Library/Application Support/runpool`, with work trees and per-runner caches in `~/Library/Caches/runpool`. Existing `RUNPOOL_BASE` installations remain active until explicitly migrated.
+New installations keep runner credentials, pool definitions and pause state in `~/Library/Application Support/runpool`, with work trees and per-runner caches in `~/Library/Caches/runpool`. Generated job-hook launchers stay under `~/.config/runpool`, whose path is safe for the runner's unquoted Bash hook invocation. Existing `RUNPOOL_BASE` installations remain active until explicitly migrated.
 
 ```bash
 runpool migrate-storage --dry-run

--- a/tests/storage-migration.sh
+++ b/tests/storage-migration.sh
@@ -18,12 +18,20 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_file() { [ -f "$1" ] || fail "missing file: $1"; }
 assert_dir() { [ -d "$1" ] || fail "missing directory: $1"; }
 assert_contains() { grep -F "$2" "$1" >/dev/null || fail "${1} does not contain ${2}"; }
+assert_link() { [ -L "$1" ] || fail "missing symlink: $1"; }
 
 mkdir -p "${legacy_dir}/pools" "${legacy_dir}/agents" "${legacy_dir}/state/pools" \
          "${legacy_dir}/alpha/runner-1/_work/repository" \
          "${legacy_dir}/alpha/runner-1/.pnpm-store" \
          "${legacy_dir}/alpha/runner-1/.npm-cache" \
+         "${legacy_dir}/alpha/runner-1/bin.2.336.0" \
+         "${legacy_dir}/alpha/runner-1/externals.2.336.0" \
          "${legacy_dir}/alpha/runner-1/tmp" "${config_dir}" "${log_dir}"
+
+touch "${legacy_dir}/alpha/runner-1/bin.2.336.0/Runner.Listener" \
+      "${legacy_dir}/alpha/runner-1/externals.2.336.0/node"
+ln -s "${legacy_dir}/alpha/runner-1/bin.2.336.0" "${legacy_dir}/alpha/runner-1/bin"
+ln -s "${legacy_dir}/alpha/runner-1/externals.2.336.0" "${legacy_dir}/alpha/runner-1/externals"
 
 cat >| "${legacy_dir}/pools/alpha.conf" <<CONF
 POOL_NAME="alpha"
@@ -63,6 +71,10 @@ assert_contains "${config_dir}/runpool.conf" "RUNPOOL_BASE=\"${support_dir}\""
 assert_contains "${support_dir}/pools/alpha.conf" "POOL_DIR=\"${support_dir}/runners/alpha\""
 assert_contains "${support_dir}/pools/alpha.conf" "POOL_CACHE_DIR=\"${cache_dir}/pools/alpha\""
 assert_file "${support_dir}/runners/alpha/runner-1/.runner"
+assert_link "${support_dir}/runners/alpha/runner-1/bin"
+assert_link "${support_dir}/runners/alpha/runner-1/externals"
+[ "$(readlink "${support_dir}/runners/alpha/runner-1/bin")" = "bin.2.336.0" ] || fail "bin link remained absolute"
+[ "$(readlink "${support_dir}/runners/alpha/runner-1/externals")" = "externals.2.336.0" ] || fail "externals link remained absolute"
 assert_contains "${support_dir}/runners/alpha/runner-1/.runner" "\"workFolder\":\"${cache_dir}/pools/alpha/runner-1/work\""
 assert_file "${cache_dir}/pools/alpha/runner-1/work/repository/file"
 assert_file "${cache_dir}/pools/alpha/runner-1/pnpm/file"
@@ -96,6 +108,8 @@ env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf"
     "${repo_dir}/bin/runpool" migrate-storage --from "${legacy_dir}" --to "${support_dir}" --remove-legacy \
     >/dev/null || fail "legacy removal failed"
 [ ! -e "${legacy_dir}" ] || fail "legacy installation remained"
+assert_file "${support_dir}/runners/alpha/runner-1/bin/Runner.Listener"
+assert_file "${support_dir}/runners/alpha/runner-1/externals/node"
 
 # An empty native root must not make an existing XDG installation invisible.
 # This is the compatibility path a user takes simply by installing the new

--- a/tests/storage-migration.sh
+++ b/tests/storage-migration.sh
@@ -10,6 +10,8 @@ support_dir="${scratch_dir}/Application Support/runpool"
 cache_dir="${scratch_dir}/Caches/runpool"
 config_dir="${scratch_dir}/config"
 log_dir="${scratch_dir}/logs"
+hook_dir="${config_dir}/runpool/hooks"
+job_hook="${scratch_dir}/job-hook.sh"
 
 cleanup() { rm -rf "${scratch_dir}"; }
 trap cleanup EXIT INT TERM
@@ -32,6 +34,8 @@ touch "${legacy_dir}/alpha/runner-1/bin.2.336.0/Runner.Listener" \
       "${legacy_dir}/alpha/runner-1/externals.2.336.0/node"
 ln -s "${legacy_dir}/alpha/runner-1/bin.2.336.0" "${legacy_dir}/alpha/runner-1/bin"
 ln -s "${legacy_dir}/alpha/runner-1/externals.2.336.0" "${legacy_dir}/alpha/runner-1/externals"
+printf '#!/bin/sh\nexit 0\n' >| "${job_hook}"
+chmod +x "${job_hook}"
 
 cat >| "${legacy_dir}/pools/alpha.conf" <<CONF
 POOL_NAME="alpha"
@@ -41,7 +45,11 @@ POOL_COUNT="1"
 POOL_DIR="${legacy_dir}/alpha"
 POOL_LABELS="self-hosted,macOS,ARM64,alpha"
 CONF
-printf 'RUNPOOL_BASE="%s"\n' "${legacy_dir}" >| "${config_dir}/runpool.conf"
+cat >| "${config_dir}/runpool.conf" <<CONF
+RUNPOOL_BASE="${legacy_dir}"
+RUNPOOL_JOB_HOOK="${job_hook}"
+RUNPOOL_HOOK_DIR="${hook_dir}"
+CONF
 chmod 600 "${config_dir}/runpool.conf"
 cat >| "${legacy_dir}/alpha/runner-1/.runner" <<RUNNER
 {"agentId":1,"workFolder":"_work"}
@@ -82,6 +90,28 @@ assert_file "${cache_dir}/pools/alpha/runner-1/npm/file"
 assert_file "${cache_dir}/pools/alpha/runner-1/tmp/file"
 assert_file "${support_dir}/agents/runpool.alpha.1.plist"
 assert_contains "${support_dir}/agents/runpool.alpha.1.plist" "${cache_dir}/pools/alpha/runner-1/pnpm"
+assert_contains "${support_dir}/agents/runpool.alpha.1.plist" "${hook_dir}/started.sh"
+assert_contains "${support_dir}/agents/runpool.alpha.1.plist" "${hook_dir}/completed.sh"
+assert_file "${hook_dir}/started.sh"
+assert_file "${hook_dir}/completed.sh"
+[ -x "${hook_dir}/started.sh" ] || fail "started hook launcher is not executable"
+[ -x "${hook_dir}/completed.sh" ] || fail "completed hook launcher is not executable"
+[ ! -d "${support_dir}/hooks" ] || fail "obsolete hook directory copied into Application Support"
+
+rm "${hook_dir}/started.sh"
+env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+    RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+    "${repo_dir}/bin/runpool" rewrite-agents >/dev/null || fail "agent rewrite failed to restore hook launcher"
+assert_file "${hook_dir}/started.sh"
+
+invalid_output="${scratch_dir}/invalid-hook-dir.txt"
+if env RUNPOOL_HOOK_DIR="${scratch_dir}/hook dir" RUNPOOL_CACHE_DIR="${cache_dir}" \
+       RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+       RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+       "${repo_dir}/bin/runpool" rewrite-agents >| "${invalid_output}" 2>&1; then
+  fail "agent rewrite accepted a hook launcher path containing whitespace"
+fi
+assert_contains "${invalid_output}" "RUNPOOL_HOOK_DIR cannot contain whitespace"
 
 status_file="${scratch_dir}/status.json"
 env RUNPOOL_CACHE_DIR="${cache_dir}" RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \


### PR DESCRIPTION
## Summary

- rewrite copied GitHub runner bin and externals symlinks so removing legacy storage cannot break the migrated installation
- keep generated job-hook launchers in the durable, space-free configuration directory required by the upstream runner Bash invocation
- reject unsafe launcher paths, recreate wrappers before pool start and report missing launchers through doctor
- remove obsolete hook wrappers from Application Support

## Verification

- stock Bash 3.2 syntax check
- shellcheck at warning severity
- isolated migration test covering absolute runner symlinks, an Application Support path containing spaces, launcher regeneration and unsafe-path rejection
- live pre-release build on aic-mbp: conformance and web-app-experimental both used self-hosted runners, passed Set up runner and executed repository steps

Closes #42
Closes #43