### PR TITLE
chore: remove contention notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ Start and stop pools, change runner counts, disable local CI and see what is run
 RunPool detects. It does not deliver. Set `RUNPOOL_NOTIFY_CMD` to any command reading one JSON object on stdin:
 
 ```json
-{ "severity": "warning", "title": "CI contention on my-mac: load 163, 5 jobs", "key": "runpool/contention/my-mac" }
+{ "severity": "critical", "title": "Pool 'main' is not registered with GitHub", "key": "runpool/unregistered/main" }
 ```
 
 Unset, it reports nothing and works as well. `contrib/notify-webhook.sh` is a reference implementation and shows the full shape.
 
-**Two things are reported**, both about the pool's own health: a machine too contended to trust a result, and runners that are up but unreachable. Failed workflow runs deliberately are not, because watching CI results should not depend on this laptop being awake.
+**Only pool connectivity failures are reported**: a missing GitHub registration, or runners that are running locally but unreachable from GitHub. Machine load remains visible in job logs and structured status but is diagnostic context, not an alert. Failed workflow runs deliberately are not reported, because watching CI results should not depend on this laptop being awake.
 
 ## Things worth knowing
 
@@ -164,7 +164,7 @@ Unset, it reports nothing and works as well. `contrib/notify-webhook.sh` is a re
 - **For an organisation, that control is GitHub's, not RunPool's.** A runner group carries `allows_public_repositories`, it is `false` by default, and runners land in the default group, so public repos in the org do not get them. RunPool reads that setting when you register and warns only if it has been turned on. [SECURITY.md](SECURITY.md) covers the whole picture, including what RunPool deliberately does not do.
 - **A runner can look healthy while GitHub has dropped it.** GitHub prunes registrations that have not connected for a long time. The local install still starts and connects and then picks up nothing, so jobs queue forever against a pool reporting as running. That is what the `github` column in `status` is for, and `reregister` fixes it.
 - **`services:` and `container:` do not force a hosted runner.** Those two workflow keys are Linux-only, but an ordinary `docker run` inside a step works anywhere Docker does, including here.
-- **More runners is not obviously more throughput**, and the contention warning scales with pool size: it defaults to six times core count, while a busy pool of N runners reaches roughly N times core count on its own. `runpool stats` describes what jobs cost and `runpool stats --queue` adds the wait before each one started, which is the figure that moves when capacity changes. Read it with the qualifier it prints: a wait can be a cold pool waking or a dependency that has not finished, and neither is fixed by more runners. `contrib/telemetry-join.sh` gives you the raw rows to separate them.
+- **More runners is not obviously more throughput.** `runpool stats` describes what jobs cost and `runpool stats --queue` adds the wait before each one started, which is the figure that moves when capacity changes. Read it with the qualifier it prints: a wait can be a cold pool waking or a dependency that has not finished, and neither is fixed by more runners. `contrib/telemetry-join.sh` gives you the raw rows to separate them.
 
 ## Not on a Mac?
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -125,13 +125,9 @@ RUNPOOL_LABEL_NS="${RUNPOOL_LABEL_NS:-runpool}"
 # only avoids churn between rapid pushes inside one working session.
 RUNPOOL_IDLE_SECS="${RUNPOOL_IDLE_SECS:-1200}"
 
-# Warn above this 1-minute load average while jobs are running. The contention
-# incidents this exists to catch ran at 163 and 184 on a 14-core machine.
-#
-# Six times core count is a starting point, not a safe default at any size.
-# A pool of N runners each forking a worker per core produces roughly N times
-# core count when it is simply busy, so once a pool passes six runners the
-# default fires on entirely healthy work. Raise it to suit the pool.
+# Load threshold exposed through structured status for consumers that want to
+# distinguish an ordinarily busy machine from exceptional contention. RunPool
+# does not notify on it: machine load is diagnostic context, not pool health.
 RUNPOOL_LOAD_WARN="${RUNPOOL_LOAD_WARN:-$(( $(sysctl -n hw.ncpu 2>/dev/null || echo 8) * 6 ))}"
 
 # Optional command receiving one JSON object on stdin whenever something is

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -14,9 +14,10 @@
 #
 # Failed workflow runs. Watching CI *results* is observability and belongs to
 # whatever receives these alerts, which can poll GitHub directly and does not
-# need a laptop to be awake to do it. runpool reports only on the health of the
-# pool itself: the machine being too contended to trust a result, and runners
-# that are running but not reachable. Those two are nobody else's to notice.
+# need a laptop to be awake to do it. runpool reports only runners that are
+# registered incorrectly or running but not reachable. That condition belongs
+# to the pool and otherwise leaves jobs queued against capacity that looks
+# healthy locally.
 #
 # Nothing watches runpool itself, and that is an accepted gap rather than an
 # oversight. A dead poller on a laptop cannot be polled from outside, and a
@@ -24,7 +25,6 @@
 # surfaces within a day. This is a CI helper, not a production pager, and the
 # point of the exercise was fewer alerts rather than a monitor for the monitor.
 
-RUNPOOL_LOAD_STATE="${RUNPOOL_STATE_DIR}/load-warned"
 RUNPOOL_HEALTH_STATE="${RUNPOOL_STATE_DIR}/health-checked"
 
 # Minimal JSON string escaping: backslash and double quote, then strip control
@@ -55,34 +55,6 @@ _rp_notify() {
     _rp_err "notifier failed: ${title}"
     return 1
   fi
-}
-
-# ---------------------------------------------------------------------------
-# Contention
-# ---------------------------------------------------------------------------
-# Several branches pushed at once turn one machine into a queue, and
-# timing-sensitive tests start failing for reasons that have nothing to do with
-# the code. That happened repeatedly at load 163 and 184 and cost real time,
-# because a contended failure and a genuine defect look identical in a log.
-# This makes them distinguishable.
-_rp_load_check() {
-  local busy=0 p load now warned
-  for p in $(_rp_pool_names); do
-    _rp_load_pool "${p}" || continue
-    busy=$(( busy + $(_rp_busy_in "${POOL_DIR}") ))
-  done
-  [ "${busy}" = "0" ] && { rm -f "${RUNPOOL_LOAD_STATE}"; return 0; }
-  load=$(sysctl -n vm.loadavg 2>/dev/null | awk '{print int($2)}')
-  [ "${load:-0}" -lt "${RUNPOOL_LOAD_WARN}" ] && return 0
-  # One notification per contention episode, not one per tick.
-  now=$(_rp_now); warned=$(cat "${RUNPOOL_LOAD_STATE}" 2>/dev/null || echo 0)
-  [ $(( now - warned )) -lt 3600 ] && return 0
-  echo "${now}" >| "${RUNPOOL_LOAD_STATE}"
-  _rp_notify warning \
-    "CI contention on $(hostname -s): load ${load}, ${busy} jobs" \
-    "runpool/contention/$(hostname -s)" \
-    "The runner pool is heavily contended. A timing-sensitive test failing right now is more likely to be the machine than a defect, so check the load before treating a red run as real." \
-    "\"Load average\":\"${load}\",\"Jobs running\":\"${busy}\",\"Threshold\":\"${RUNPOOL_LOAD_WARN}\",\"Host\":\"$(hostname -s)\""
 }
 
 # ---------------------------------------------------------------------------

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -125,9 +125,8 @@ _rp_status_json() {
   local local_only="${1:-0}" p running busy gh reg online first=1 paused="false" pool_paused="false" wr wfirst
   _rp_paused && paused="true"
   # Machine state belongs here rather than being recomputed by every caller.
-  # The contention threshold in particular is configurable, so a caller that
-  # derived it from core count would quietly disagree with the tool that acts
-  # on it.
+  # The load threshold is configurable, so a status consumer that derived it
+  # from core count would quietly disagree with other status consumers.
   local load cores
   load=$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}')
   cores=$(sysctl -n hw.ncpu 2>/dev/null || echo 0)
@@ -272,7 +271,7 @@ _rp_doctor() {
   tick="${RUNPOOL_LABEL_NS}.tick"
   clean="${RUNPOOL_LABEL_NS}.clean"
   if _rp_agent_loaded "${tick}"; then
-    _rp_doctor_ok "the tick agent is loaded: autoscale, idle standdown, contention and health"
+    _rp_doctor_ok "the tick agent is loaded: autoscale, idle standdown and health"
   elif [ -f "${HOME}/Library/LaunchAgents/${tick}.plist" ]; then
     _rp_doctor_fail "the tick agent is installed but not loaded, so nothing autoscales: a queued job waits for a manual 'runpool up' and every pool still reports as healthy" \
                     "fix: runpool schedule install   (rewrites and reloads it)"
@@ -742,7 +741,7 @@ _rp_tick() {
     mkdir "${RUNPOOL_TICK_LOCK}" 2>/dev/null || return 0
   fi
   trap 'rm -rf "${RUNPOOL_TICK_LOCK}"' EXIT INT TERM
-  _rp_autoscale; _rp_sweep; _rp_load_check; _rp_health_check; _rp_clean_if_overdue
+  _rp_autoscale; _rp_sweep; _rp_health_check; _rp_clean_if_overdue
   rm -rf "${RUNPOOL_TICK_LOCK}"
   trap - EXIT INT TERM
 }
@@ -823,7 +822,7 @@ _rp_schedule_install() {
   launchctl load   "${HOME}/Library/LaunchAgents/${tick}.plist"
   launchctl unload "${HOME}/Library/LaunchAgents/${clean}.plist" 2>/dev/null
   launchctl load   "${HOME}/Library/LaunchAgents/${clean}.plist"
-  _rp_log "scheduler installed: tick 60s (autoscale, idle-down, contention), clean daily 04:00"
+  _rp_log "scheduler installed: tick 60s (autoscale, idle-down, health), clean daily 04:00"
 }
 
 _rp_schedule_remove() {

--- a/runpool.conf.example
+++ b/runpool.conf.example
@@ -37,11 +37,11 @@
 # grace only avoids churn between rapid pushes in one working session.
 # RUNPOOL_IDLE_SECS=1200
 
-# Warn above this 1-minute load average while jobs are running.
+# Load threshold exposed in structured status. It does not send an alert.
 # Defaults to six times core count, which sits clear of ordinary work.
 # Raise this as the pool grows: a busy pool of N runners reaches about N times
-# core count on its own, so the default of six times core count starts alerting
-# on healthy work once a pool passes six runners.
+# core count on its own, so the default may stop distinguishing exceptional
+# contention once a pool passes six runners.
 # RUNPOOL_LOAD_WARN=84
 
 # Stamp machine state into every job, so a contended failure and a real defect

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -227,7 +227,7 @@ Persistent runners never clean up after themselves. `runpool clean` prunes work 
 
 RunPool ships with **no notifier** and works fully without one. Set `RUNPOOL_NOTIFY_CMD` to a command reading one JSON object on stdin; `contrib/notify-webhook.sh` is a reference implementation.
 
-**Do not add notification logic to runpool.** It reports two conditions, both about the pool's own health: contention, and runners that are up but unreachable. Watching workflow *results* belongs to whatever receives the notifications, because that should not depend on the laptop being awake.
+**Do not add notification logic to runpool.** It reports only pool connectivity failures: a missing GitHub registration, or runners that are up locally but unreachable. Machine load stays in job logs and structured status as diagnostic context. Watching workflow *results* belongs to whatever receives the notifications, because that should not depend on the laptop being awake.
 
 ## Things that will bite
 


### PR DESCRIPTION
## Summary

- stop treating machine load as a pool-health notification
- retain load telemetry in job logs and structured status
- keep missing-registration and unreachable-runner alerts unchanged

## Verification

- Bash 3.2 parsing
- shellcheck at warning severity
- isolated structured-status smoke test

Closes #45