### PR TITLE
feat: guard set-count against a count that has moved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
           done
       - name: storage migration
         run: tests/storage-migration.sh
+      - name: set-count guards
+        run: tests/set-count-guards.sh

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | Command | |
 |---|---|
 | `register <pool> --repo OWNER/REPO\|--org ORG [--count N] [--watch OWNER/REPO,...] [--allow-public]` | Create a pool and configure its runners |
-| `set-count <pool> N` | Change a pool's runner count |
+| `set-count <pool> N [--if-count M]` | Change a pool's runner count. `--if-count` refuses unless it is currently M |
 | `apply [--dry-run] [--file PATH]` | Reconcile the machine to a file describing its pools |
 | `up` / `down <pool>` | Bring a pool online, or stand it down |
 | `status [--json] [--local]` | Local state alongside what GitHub actually sees |
 | `doctor` | Why is nothing picking this up. Reports; changes nothing |
+| `version` | Print the installed version |
 | `pools` | List registered pools |
 | `reregister <pool>` | Recreate GitHub registrations, keeping the local install |
 | `remove <pool>` | Deregister and delete a pool |
@@ -67,6 +68,8 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | `pause [pool]` / `resume [pool]` | Global kill switch, or persistent per-pool pause |
 | `schedule install\|remove` | The background agents that drive everything above |
 | `migrate-storage [--dry-run]` | Move a legacy installation into macOS storage |
+
+**`set-count` is absolute, so a caller that reads a count and acts on it later needs `--if-count`.** A pool changed in between turns a growth into a shrink, and shrinking deregisters runners. `--if-count M` refuses unless the pool is still at M, and one resize per pool runs at a time, so two callers cannot interleave. Deregistering a runner that GitHub then keeps is reported as a failure rather than logged and passed over: a registration GitHub still holds for a runner that no longer exists attracts jobs that queue forever.
 
 **`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`: one API call per pool per minute is thousands a day, and it makes a passive readout fail whenever the network does.
 

--- a/bin/runpool
+++ b/bin/runpool
@@ -31,6 +31,11 @@ RUNPOOL_ROOT="$(dirname "${RUNPOOL_BIN_DIR}")"
 RUNPOOL_SELF="${RUNPOOL_BIN_DIR}/runpool"
 export RUNPOOL_SELF
 
+# The released version, and the only place it is written. The Homebrew formula
+# builds from a git tag, so a tag without a matching bump here ships a binary
+# that misreports itself.
+RUNPOOL_VERSION="0.9.0"
+
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"
 # shellcheck source=lib/lifecycle.sh
@@ -98,7 +103,19 @@ Options:
 HELP
       ;;
     set-count)
-      echo "Usage: runpool set-count <pool> <n>"
+      cat <<'HELP'
+Usage: runpool set-count <pool> <n> [options]
+
+Change a pool's runner count. Growing registers new runners with GitHub;
+shrinking deregisters them, which setting the number back does not undo.
+
+Options:
+  --if-count <n>                Refuse unless the pool currently has exactly
+                                <n> runners. For a caller that read the count,
+                                asked a question, and is now acting on the
+                                answer: without it a pool changed in between
+                                can be shrunk by a command meant to grow it.
+HELP
       ;;
     apply)
       cat <<'HELP'
@@ -115,7 +132,7 @@ HELP
     up|down)
       echo "Usage: runpool ${command} <pool>"
       ;;
-    up-all|down-all|tick|autoscale|sweep|pools|doctor)
+    up-all|down-all|tick|autoscale|sweep|pools|doctor|version)
       echo "Usage: runpool ${command}"
       ;;
     pause|resume)
@@ -188,6 +205,7 @@ case "${cmd}" in
   down-all)       _rp_down_all "$@" ;;
   remove)         _rp_remove "$@" ;;
   status)         _rp_status "$@" ;;
+  version|--version|-V) echo "runpool ${RUNPOOL_VERSION}" ;;
   doctor)         _rp_doctor "$@" ;;
   pools)          _rp_pools ;;
   stats)          _rp_stats "$@" ;;

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -409,6 +409,64 @@ _rp_fetch_runner_tarball() {
 # runners were registered under different names. The agent id is written by the
 # runner and is exact. The file carries a UTF-8 BOM, hence grep rather than jq.
 #   $1 runner_dir  $2 scope  $3 target
+# A runner registration token for $1 $2, or nothing with a non-zero status.
+#
+# `gh api --jq` prints the error body to stdout when the request fails, so
+# every caller here used to accept
+#
+#   {"message":"Not Found","documentation_url":"...","status":"404"}
+#
+# as a token, because it tested only that the value was non-empty. config.sh
+# then failed on a garbage token, deep in the runner's own output, saying
+# nothing about the missing repository or the missing admin rights that
+# actually caused it.
+#
+# The shape test is what makes this reliable rather than the exit status
+# alone: a token is alphanumeric, and no JSON body can be.
+_rp_registration_token() {
+  local token
+  token=$(gh api -X POST "$(_rp_scope_path "$1" "$2")/actions/runners/registration-token" \
+            --jq '.token' 2>/dev/null) || return 1
+  case "${token}" in
+    ''|*[!A-Za-z0-9]*) return 1 ;;
+  esac
+  echo "${token}"
+}
+
+# ---------------------------------------------------------------------------
+# Per-pool resize lock
+# ---------------------------------------------------------------------------
+# Two resizes of one pool must not interleave. A grow fetches the runner
+# tarball and runs config.sh once per new runner, so it can be working for
+# tens of seconds, and --if-count does not help: both callers would pass their
+# own check before either wrote a count.
+#
+# mkdir is the lock, for the reason the tick already uses it: atomic on every
+# POSIX filesystem, and macOS has no flock. The stale break keeps a resize
+# killed halfway from wedging a pool for good. Thirty minutes is far longer
+# than any real resize and short enough to recover from without a manual step.
+RUNPOOL_RESIZE_STALE=1800
+
+_rp_resize_lock_dir() { echo "${RUNPOOL_STATE_DIR}/resize.$1.lock"; }
+
+_rp_resize_lock() {
+  local lock age; lock="$(_rp_resize_lock_dir "$1")"
+  mkdir -p "${RUNPOOL_STATE_DIR}" 2>/dev/null
+  if mkdir "${lock}" 2>/dev/null; then return 0; fi
+
+  age=$(( $(_rp_now) - $(stat -f %m "${lock}" 2>/dev/null || echo 0) ))
+  if [ "${age}" -lt "${RUNPOOL_RESIZE_STALE}" ]; then
+    _rp_err "pool '$1' is already being resized — wait for that to finish, then retry."
+    return 1
+  fi
+  _rp_log "resize: breaking a stale lock on '$1' (${age}s old)"
+  rm -rf "${lock}"
+  mkdir "${lock}" 2>/dev/null || { _rp_err "could not lock pool '$1' for resize"; return 1; }
+  return 0
+}
+
+_rp_resize_unlock() { rm -rf "$(_rp_resize_lock_dir "$1")"; }
+
 _rp_deregister_runner() {
   local runner_dir="$1" scope="$2" target="$3" id url
   [ -f "${runner_dir}/.runner" ] || return 0   # never registered

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -153,9 +153,8 @@ _rp_register() {
       mkdir -p "${runner_dir}"
       mkdir -p "${cache_dir}/work" "${cache_dir}/pnpm" "${cache_dir}/npm" "${cache_dir}/tmp"
       [ -f "${runner_dir}/config.sh" ] || tar -xzf "${tarball}" -C "${runner_dir}" || return 1
-      token=$(gh api -X POST "$(_rp_scope_path "${scope}" "${target}")/actions/runners/registration-token" \
-                --jq '.token' 2>/dev/null)
-      [ -n "${token}" ] || { _rp_err "${name} runner-${i}: no registration token (need admin on ${target})"; return 1; }
+      token="$(_rp_registration_token "${scope}" "${target}")" \
+        || { _rp_err "${name} runner-${i}: no registration token — check 'gh auth status', that ${target} exists, and that you have admin on it"; return 1; }
       runner_name="$(hostname -s)-${name}-${i}"
       _rp_log "${name} runner-${i}: registering as '${runner_name}'"
       ( cd "${runner_dir}" && ./config.sh --unattended --replace \
@@ -233,14 +232,70 @@ _rp_write_pool_watch() {
   ' "${conf}" >| "${conf}.tmp" && mv -f "${conf}.tmp" "${conf}"
 }
 
+# Arguments used to be read as $1 and $2 with anything further ignored in
+# silence, which is how a mistyped flag became invisible. They are parsed
+# properly now and anything unrecognised is refused.
+_rp_set_count_usage() { echo "usage: runpool set-count <pool> <n> [--if-count <n>]"; }
+
 _rp_set_count() {
   _rp_require gh || return 1
-  local name="$1" want="$2"
-  [ -n "${name}" ] && [ -n "${want}" ] || { _rp_err "usage: runpool set-count <pool> <n>"; return 1; }
+  local name="" want="" expect="" rc
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --if-count)
+        [ $# -ge 2 ] || { _rp_err "--if-count needs a value ($(_rp_set_count_usage))"; return 1; }
+        expect="$2"; shift 2 ;;
+      --if-count=*)
+        expect="${1#*=}"; shift ;;
+      -*)
+        _rp_err "unknown flag: $1 ($(_rp_set_count_usage))"; return 1 ;;
+      *)
+        if   [ -z "${name}" ]; then name="$1"
+        elif [ -z "${want}" ]; then want="$1"
+        else _rp_err "unexpected argument: $1 ($(_rp_set_count_usage))"; return 1
+        fi
+        shift ;;
+    esac
+  done
+
+  [ -n "${name}" ] && [ -n "${want}" ] || { _rp_err "$(_rp_set_count_usage)"; return 1; }
+  # Checked before the name reaches a lock path, which is built from it.
+  _rp_valid_pool_name "${name}" || { _rp_err "invalid pool name: '${name}'"; return 1; }
   _rp_valid_count "${want}" || { _rp_err "count: $(_rp_count_rule), got '${want}'"; return 1; }
+  if [ -n "${expect}" ]; then
+    _rp_valid_count "${expect}" || { _rp_err "--if-count: $(_rp_count_rule), got '${expect}'"; return 1; }
+  fi
+
+  # Held across the whole resize, and released on every exit path by doing the
+  # work in a separate function rather than with a trap. `apply` calls this in
+  # a loop and installs traps of its own, which a trap set here would clobber.
+  _rp_resize_lock "${name}" || return 1
+  _rp_set_count_locked "${name}" "${want}" "${expect}"
+  rc=$?
+  _rp_resize_unlock "${name}"
+  return ${rc}
+}
+
+_rp_set_count_locked() {
+  local name="$1" want="$2" expect="$3"
   _rp_load_pool "${name}" || return 1
 
   local have="${POOL_COUNT}"
+
+  # Compare-and-swap. `set-count` writes an absolute number, so a caller that
+  # read the count, asked the user a question, and then wrote what it worked
+  # out beforehand can turn a growth into a shrink and deregister runners
+  # nobody agreed to. Refusing on a moved count is what makes that caller safe.
+  #
+  # Checked before the "already at that count" shortcut below, because a
+  # premise that no longer holds is a failure whatever the target happens to
+  # be: returning success for `set-count p 6 --if-count 4` on a pool that has
+  # become 6 would tell the caller its stale view was right.
+  if [ -n "${expect}" ] && [ "${expect}" != "${have}" ]; then
+    _rp_err "'${name}' has ${have} runner(s), not ${expect} — refusing to resize. Something else changed it; re-read the count and retry."
+    return 1
+  fi
+
   if [ "${want}" = "${have}" ]; then _rp_log "pool '${name}': already ${have} runner(s)"; return 0; fi
 
   # Resizing either kills a live job or races a registration against one.
@@ -250,7 +305,7 @@ _rp_set_count() {
     return 1
   fi
 
-  local was_up=0 i runner_dir cache_dir label token runner_name tarball
+  local was_up=0 orphaned=0 i runner_dir cache_dir label token runner_name tarball
   _rp_agent_loaded "$(_rp_label "${name}" 1)" && was_up=1
 
   if [ "${want}" -gt "${have}" ]; then
@@ -263,9 +318,8 @@ _rp_set_count() {
       _rp_prepare_runner_cache "${name}" "${i}"
       [ -f "${runner_dir}/config.sh" ] || tar -xzf "${tarball}" -C "${runner_dir}" || return 1
       if [ ! -f "${runner_dir}/.runner" ]; then
-        token=$(gh api -X POST "$(_rp_scope_path "${POOL_SCOPE}" "${POOL_TARGET}")/actions/runners/registration-token" \
-                  --jq '.token' 2>/dev/null)
-        [ -n "${token}" ] || { _rp_err "${name} runner-${i}: no registration token"; return 1; }
+        token="$(_rp_registration_token "${POOL_SCOPE}" "${POOL_TARGET}")" \
+          || { _rp_err "${name} runner-${i}: no registration token — check 'gh auth status', that ${POOL_TARGET} exists, and that you have admin on it"; return 1; }
         runner_name="$(hostname -s)-${name}-${i}"
         _rp_log "${name} runner-${i}: registering as '${runner_name}'"
         ( cd "${runner_dir}" && ./config.sh --unattended --replace \
@@ -296,7 +350,11 @@ _rp_set_count() {
       # Deregister before deleting. A runner removed locally but left
       # registered shows on GitHub as permanently offline and still gets
       # counted when a job looks for somewhere to run.
-      _rp_deregister_runner "${runner_dir}" "${POOL_SCOPE}" "${POOL_TARGET}"
+      #
+      # Counted rather than fatal. Stopping here would leave the pool half
+      # shrunk against a count already written, so the local cleanup finishes
+      # and the command reports the failure at the end instead.
+      _rp_deregister_runner "${runner_dir}" "${POOL_SCOPE}" "${POOL_TARGET}" || orphaned=$(( orphaned + 1 ))
       rm -f "${RUNPOOL_AGENT_DIR}/${label}.plist"
       rm -rf "${runner_dir}"
       [ "${POOL_LEGACY_LAYOUT}" = "1" ] || rm -rf "${cache_dir}"
@@ -313,6 +371,17 @@ _rp_set_count() {
   _rp_log "pool '${name}': ${have} -> ${want} runner(s)"
   if [ "${was_up}" = "1" ] && ! _rp_pool_paused "${name}"; then
     _rp_load_pool "${name}" && _rp_up "${name}"
+  fi
+
+  # Reported last, and as a failure, because everything above succeeded and it
+  # would otherwise read as a clean resize. A registration GitHub still holds
+  # for a runner that no longer exists attracts jobs that then queue forever,
+  # which is the failure this whole tool exists to avoid. The DELETE for each
+  # one is in the log above, and `runpool doctor` keeps reporting the mismatch
+  # until they are gone.
+  if [ "${orphaned}" -gt 0 ]; then
+    _rp_err "${orphaned} runner(s) are still registered on ${POOL_TARGET} — resize finished locally but GitHub was not updated."
+    return 1
   fi
   return 0
 }
@@ -338,9 +407,8 @@ _rp_reregister() {
   while [ "${i}" -le "${POOL_COUNT}" ]; do
     runner_dir="${POOL_DIR}/runner-${i}"
     [ -f "${runner_dir}/config.sh" ] || { _rp_err "${name} runner-${i}: no install at ${runner_dir}"; return 1; }
-    token=$(gh api -X POST "$(_rp_scope_path "${POOL_SCOPE}" "${POOL_TARGET}")/actions/runners/registration-token" \
-              --jq '.token' 2>/dev/null)
-    [ -n "${token}" ] || { _rp_err "${name} runner-${i}: no registration token (need admin on ${POOL_TARGET})"; return 1; }
+    token="$(_rp_registration_token "${POOL_SCOPE}" "${POOL_TARGET}")" \
+      || { _rp_err "${name} runner-${i}: no registration token — check 'gh auth status', that ${POOL_TARGET} exists, and that you have admin on it"; return 1; }
     runner_name="$(hostname -s)-${name}-${i}"
     # config.sh refuses to reconfigure over an existing registration, and
     # --replace only covers a name collision on the server side. Note that
@@ -657,7 +725,7 @@ _rp_down_all() { local p; for p in $(_rp_pool_names); do _rp_down "${p}" "${1:-}
 _rp_remove() {
   _rp_load_pool "$1" || return 1
   _rp_down "$1"
-  local i runner_dir label
+  local i runner_dir label orphaned=0
   # Iterate the directories that exist rather than 1..POOL_COUNT. A pool whose
   # count was lowered by hand still has higher-numbered runners on disk and
   # registered with GitHub, and counting to POOL_COUNT would leave them behind
@@ -667,7 +735,7 @@ _rp_remove() {
     runner_dir="${runner_dir%/}"
     i="${runner_dir##*/runner-}"
     label="$(_rp_label "$1" "${i}")"
-    _rp_deregister_runner "${runner_dir}" "${POOL_SCOPE}" "${POOL_TARGET}"
+    _rp_deregister_runner "${runner_dir}" "${POOL_SCOPE}" "${POOL_TARGET}" || orphaned=$(( orphaned + 1 ))
     rm -f "${RUNPOOL_AGENT_DIR}/${label}.plist"
     rm -rf "${runner_dir}"
   done
@@ -679,4 +747,14 @@ _rp_remove() {
   rm -f "$(_rp_pool_pause_flag "$1")"
   rm -f "$(_rp_pool_conf "$1")"
   _rp_log "pool '$1' removed"
+
+  # Worse here than for a shrink, and worth saying so. After a shrink the pool
+  # still exists and `status` and `doctor` go on reporting the mismatch; after
+  # a remove there is no pool left to report it, so this message and the DELETE
+  # commands above it are the only record that anything is outstanding.
+  if [ "${orphaned}" -gt 0 ]; then
+    _rp_err "${orphaned} runner(s) are still registered on ${POOL_TARGET}. The pool is gone locally, so nothing will report this again — run the DELETE commands above, or remove them from GitHub's runner settings."
+    return 1
+  fi
+  return 0
 }

--- a/tests/set-count-guards.sh
+++ b/tests/set-count-guards.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Run against a scratch installation only. Every case here is refused before
+# set-count reaches GitHub, so nothing registers a runner or calls the API.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+base_dir="${scratch_dir}/base"
+cache_dir="${scratch_dir}/cache"
+config_dir="${scratch_dir}/config"
+log_dir="${scratch_dir}/logs"
+
+cleanup() { rm -rf "${scratch_dir}"; }
+trap cleanup EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "${base_dir}/pools" "${base_dir}/state" "${cache_dir}" "${config_dir}" "${log_dir}"
+
+cat >"${base_dir}/pools/alpha.conf" <<CONF
+POOL_SCOPE="repo"
+POOL_TARGET="acme/widget"
+POOL_COUNT="4"
+POOL_DIR="${base_dir}/runners/alpha"
+POOL_CACHE_DIR="${cache_dir}/pools/alpha"
+POOL_LABELS="self-hosted,macOS,ARM64,alpha"
+CONF
+
+runpool() {
+  env RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${cache_dir}" \
+      RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+      RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log" \
+      "${repo_dir}/bin/runpool" "$@"
+}
+
+count_now() { sed -n 's/^POOL_COUNT="\(.*\)"$/\1/p' "${base_dir}/pools/alpha.conf"; }
+
+# Every refusal below must leave the pool exactly as it was. Checked after each
+# one rather than at the end, so a failure names the case that caused it.
+assert_untouched() {
+  [ "$(count_now)" = "4" ] || fail "$1: POOL_COUNT changed to $(count_now)"
+}
+
+assert_refused() {
+  local what="$1"; shift
+  local out rc
+  out=$(runpool set-count "$@" 2>&1); rc=$?
+  [ "${rc}" -ne 0 ] || fail "${what}: exited 0, expected a refusal. Output: ${out}"
+  assert_untouched "${what}"
+  echo "${out}"
+}
+
+# --- the compare-and-swap -----------------------------------------------------
+out=$(assert_refused "stale --if-count" alpha 5 --if-count 3)
+case "${out}" in
+  *"has 4 runner(s), not 3"*) ;;
+  *) fail "stale --if-count: unhelpful message: ${out}" ;;
+esac
+
+# A premise that no longer holds is a failure whatever the target is. Without
+# this, asking for the count the pool already has would report success and tell
+# a caller its stale view had been correct.
+assert_refused "stale --if-count reaching the no-op shortcut" alpha 4 --if-count 3 >/dev/null
+
+out=$(runpool set-count alpha 4 --if-count 4 2>&1) \
+  || fail "matching --if-count on an unchanged count should succeed: ${out}"
+case "${out}" in
+  *"already 4 runner(s)"*) ;;
+  *) fail "matching --if-count: expected the no-op message, got: ${out}" ;;
+esac
+assert_untouched "matching --if-count"
+
+assert_refused "--if-count with no value" alpha 5 --if-count >/dev/null
+assert_refused "--if-count with a bad value" alpha 5 --if-count 0 >/dev/null
+
+# --- arguments are no longer ignored in silence -------------------------------
+# These used to be read as $1 and $2 with anything further dropped, so a
+# mistyped flag did nothing and said nothing.
+assert_refused "unknown flag" alpha 5 --no-such-flag >/dev/null
+assert_refused "trailing argument" alpha 5 extra >/dev/null
+assert_refused "missing count" alpha >/dev/null
+assert_refused "unknown pool" nosuchpool 5 >/dev/null
+
+# --- the resize lock ----------------------------------------------------------
+mkdir -p "${base_dir}/state/resize.alpha.lock"
+out=$(assert_refused "held resize lock" alpha 5)
+case "${out}" in
+  *"already being resized"*) ;;
+  *) fail "held lock: unhelpful message: ${out}" ;;
+esac
+
+# A resize killed halfway must not wedge the pool for good. Backdate the lock
+# past the stale window and the next attempt has to get in.
+#
+# Probed with a mismatched --if-count rather than a real resize: that is
+# refused just after the lock is taken and before anything is fetched, so the
+# test stays offline and fast. Reaching the --if-count message at all is the
+# proof, because a lock still held would have refused earlier.
+touch -t 200001010000 "${base_dir}/state/resize.alpha.lock"
+out=$(runpool set-count alpha 5 --if-count 3 2>&1)
+case "${out}" in
+  *"already being resized"*) fail "stale lock was not broken: ${out}" ;;
+  *"has 4 runner(s), not 3"*) ;;
+  *) fail "stale lock: unexpected outcome: ${out}" ;;
+esac
+[ ! -d "${base_dir}/state/resize.alpha.lock" ] || fail "lock not released after the attempt"
+assert_untouched "stale lock"
+
+# --- registration tokens ------------------------------------------------------
+# `gh api --jq` prints the error body to stdout when a request fails, so a
+# non-empty test accepts a 404 body as a token and hands it to config.sh. Both
+# halves are checked against a stubbed gh, so this stays offline.
+stub_dir="${scratch_dir}/stub"
+mkdir -p "${stub_dir}"
+
+with_stub_gh() {
+  cat >"${stub_dir}/gh"
+  chmod +x "${stub_dir}/gh"
+}
+
+token_for() (
+  PATH="${stub_dir}:${PATH}"
+  export RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${cache_dir}" \
+         RUNPOOL_CONFIG="${config_dir}/runpool.conf" RUNPOOL_POOLS_FILE="${config_dir}/pools" \
+         RUNPOOL_LOG_DIR="${log_dir}" RUNPOOL_LOG="${log_dir}/runpool.log"
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" >/dev/null 2>&1
+  _rp_registration_token repo acme/widget
+)
+
+with_stub_gh <<'STUB'
+#!/bin/bash
+echo '{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}'
+exit 1
+STUB
+if out=$(token_for 2>/dev/null); then
+  fail "a 404 body was accepted as a registration token: ${out}"
+fi
+
+with_stub_gh <<'STUB'
+#!/bin/bash
+echo "AZY7QF3KTPLMN2RSTUVWX4YZ6ABCD"
+STUB
+out=$(token_for 2>/dev/null) || fail "a valid token was rejected"
+[ "${out}" = "AZY7QF3KTPLMN2RSTUVWX4YZ6ABCD" ] || fail "token mangled: ${out}"
+
+# --- version ------------------------------------------------------------------
+for flag in version --version -V; do
+  out=$(runpool "${flag}" 2>&1) || fail "runpool ${flag} exited non-zero: ${out}"
+  case "${out}" in
+    "runpool "[0-9]*.[0-9]*.[0-9]*) ;;
+    *) fail "runpool ${flag}: expected a version, got: ${out}" ;;
+  esac
+done
+
+echo "OK: set-count guards"


### PR DESCRIPTION
`set-count` writes an absolute number, so a caller that reads the count, asks the user a question, and then writes the number it worked out beforehand can turn a growth into a shrink and deregister runners nobody agreed to. The Raycast extension is exactly that caller.

## The guard

- **`--if-count N`** refuses unless the pool is currently at N. Checked before the "already at that count" shortcut, because a premise that no longer holds is a failure whatever the target happens to be.
- **One resize per pool at a time.** `--if-count` cannot help two callers that both check before either writes, and a grow fetches the runner tarball and runs `config.sh` per runner, so it can be working for tens of seconds. `mkdir` is the lock, as the tick already does it, with a stale break. Released without a trap: `apply` calls `set-count` in a loop and installs traps of its own.
- **Arguments are parsed.** They were read as `$1` and `$2` with anything further dropped in silence, which is how a mistyped flag did nothing and said nothing.

## Two defects found alongside it

**A failed deregistration was logged and passed over.** Shrinking or removing a pool with `gh` signed out reported success while GitHub kept registrations for runners that no longer exist. Jobs routed to them queue forever, which is the failure this tool exists to prevent. Both paths now finish the local cleanup and exit non-zero. `remove` says more, because it leaves no pool for `doctor` to keep reporting.

**`gh api --jq` prints the error body to stdout when a request fails.** Testing the token for non-emptiness therefore accepted

```
{"message":"Not Found","documentation_url":"...","status":"404"}
```

as a registration token and handed it to `config.sh`, which failed deep in the runner's own output saying nothing about the missing repository or admin rights behind it. All three call sites now go through a helper that checks the request succeeded and that the result has the shape of a token.

## Also

`runpool version`, which did not exist.

## Testing

`tests/set-count-guards.sh` covers every refusal above and is wired into CI. It is offline and runs in under two seconds: the guards all fire before any API call, and the token cases use a stubbed `gh`. Verified to fail against the pre-change tree, so it has teeth.

`shellcheck --severity=warning` clean, parses under stock bash 3.2, and `tests/storage-migration.sh` still passes.