### PR TITLE
docs: tighten the README, restructure the skill, fill gaps in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Break any of these and the tool stops being what it is.
 
 - **Bash 3.2.** Stock macOS ships bash 3.2 and the tool must run there. No associative arrays, no `mapfile`/`readarray`, no `${var^^}`, no `&>>`. CI parses every file under `/bin/bash` on a macOS runner to enforce this.
 - **macOS only.** launchd, `sysctl`, `~/Library` paths, the `osx-arm64` runner build. Do not add Linux or Windows support: that case is already well served by actions-runner-controller and garm, and serving it would mean competing where there is no gap.
-- **No notifier.** `lib/notify.sh` writes one JSON object to whatever `RUNPOOL_NOTIFY_CMD` names. It must never grow mail sending, address routing, severity policy, dedup windows, or a dependency on a particular service. An earlier version of this tool had all of those and it is exactly why it could not be published.
+- **No notifier.** `lib/notify.sh` writes one JSON object to whatever `RUNPOOL_NOTIFY_CMD` names. It must never grow mail sending, address routing, severity policy, dedup windows, or a dependency on a particular service. An earlier version had all of those and it is exactly why it could not be published.
 - **No workflow-result watching.** Reporting on failed CI runs is observability and belongs to whatever receives the notifications, which can poll GitHub without depending on a laptop being awake. This tool reports only on the health of the pool itself.
 - **Nothing personal in the repository.** No real organisation names, repository names, hostnames, addresses or paths, in code, comments, docs or examples. Use `acme` / `acme-inc` / `me/side-project`. Installation specifics belong in the user's config file, never here.
 - **No secrets, ever.** Registration credentials live in the runtime directory, which is outside this repo by design. Nothing in a checkout should reveal anything about the machine it came from.
@@ -23,7 +23,7 @@ Break any of these and the tool stops being what it is.
 ## Layout
 
 ```
-bin/runpool          the executable and its dispatcher
+bin/runpool          the executable, its dispatcher, its help text, and RUNPOOL_VERSION
 lib/common.sh        config, logging, pool loading, launch agents, deregistration
 lib/lifecycle.sh     register, set-count, up, down, reregister, remove
 lib/apply.sh         the pools file, and reconciling the machine to it
@@ -31,15 +31,65 @@ lib/scheduler.sh     status, doctor, autoscale, sweep, clean, schedule
 lib/notify.sh        the optional notifier hook and what triggers it
 lib/stats.sh         job durations from recorded telemetry, and queue times
                      via contrib/telemetry-join.sh
+tests/               offline test scripts, all three run by CI
 contrib/             optional pieces the user opts into: job hook, webhook notifier,
                      demo status fixture
 skills/runpool/      agent skill for *using* runpool, shipped with the tool
 assets/icon.svg      the icon, source of truth; PNGs are rendered from it
 ```
 
-**`skills/runpool/SKILL.md` and this file have different audiences and must not converge.** This file is for changing runpool. The skill is for an agent wiring some other repository to it, choosing a scope, or working out why a job is queued and nothing has picked it up. If a change alters observable behaviour, the skill needs updating; if it alters how the code is structured, this file does.
+**`skills/runpool/` and this file have different audiences and must not converge.** This file is for changing runpool. The skill is for an agent wiring some other repository to it, choosing a scope, sizing a pool, or working out why a job is queued and nothing has picked it up. **If a change alters observable behaviour, the skill needs updating**; if it alters how the code is structured, this file does. The skill is a hub plus `SIZING.md` and `MIGRATION.md`; keep it that shape rather than growing SKILL.md back into one flat file.
 
 **The split by concern is load-bearing**, not cosmetic. It is what lets the notifier be absent, and what keeps the pools file out of everything that does not read one. Keep new code in the part that owns the concern; if something does not fit, that is a signal the concern is new, not that the split is wrong.
+
+## Conventions
+
+- **Functions are prefixed `_rp_`.** Only the dispatcher in `bin/runpool` is public surface.
+- **`set -uo pipefail`, deliberately without `-e`.** Most logic branches on exit status and the failures that matter are handled with explicit `|| return`. Do not add `-e`.
+- **Sourced fragments carry `# shellcheck shell=bash`** on line one, because they have no shebang and shellcheck cannot infer the dialect otherwise.
+- **Use `>|`, not `>`.** A shell with `noclobber` set refuses to truncate an existing file, which has silently broken this tool twice: once on the activity timestamp and once on launch agent rewriting.
+- **Use `find`, not globs, over directories that may be empty.** An unmatched glob either expands to a literal or aborts the function depending on the shell.
+- **Declare every `local` once, at the top of a function.** Re-declaring inside a loop makes some shells print it as a typeset assignment, which has leaked stray lines into logs.
+- **A constant read in only one file belongs in that file.** shellcheck analyses each file independently, so one defined in `lib/common.sh` and read only in `bin/runpool` trips SC2034.
+- **Comments explain why.** Most of the non-obvious lines here exist because something failed in a specific way, and the comment records that failure. Preserve those; they are the reason the code looks as it does.
+
+## Configuration precedence
+
+Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **A new setting has to be added in four places in that block** — the snapshot, the restore, the `unset`, and the `export` — or it silently becomes un-overridable, or leaks a `_rp_env_*` variable, or fails to reach a child process.
+
+`RUNPOOL_POOLS_FILE` is deliberately derived from `XDG_CONFIG_HOME` rather than from `RUNPOOL_CONFIG`'s directory, so that pointing the config at `/dev/null` to isolate a test does not also move the pools file somewhere unexpected. **The corollary is that neither `RUNPOOL_CONFIG` nor `RUNPOOL_BASE` isolates it** — it has to be set on its own, or overridden per run with `apply --file`. `/dev/null` is a valid value: `apply` tests for a readable non-directory rather than a regular file, so the isolation idiom means the same thing for both settings.
+
+## Working on it
+
+```bash
+# Exactly what CI runs. Note tests/*.sh in both: omit it and CI checks more than you did.
+/bin/bash -n bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
+shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
+
+tests/storage-migration.sh
+tests/set-count-guards.sh
+```
+
+Without shellcheck installed, Docker gives the same result and leaves nothing behind. Skipping the check is how CI goes red unnoticed:
+
+```bash
+docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
+  --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
+```
+
+**The tests run offline and make no API calls**, which is what makes them safe anywhere. A new test must keep that: fabricate pool configs under a scratch `RUNPOOL_BASE`, stub `gh` where a path needs it, and prefer a guard refused early over one that reaches the network. `tests/set-count-guards.sh` probes its lock case with a mismatched `--if-count` for that reason, since a real resize fetches the runner tarball first.
+
+**Test against a scratch directory, never a real installation:**
+
+```bash
+RUNPOOL_BASE=/tmp/rp-test RUNPOOL_CONFIG=/dev/null ./bin/runpool status --json
+```
+
+**`RUNPOOL_BASE` does not move the pools file**, per *Configuration precedence* above. Anything touching `apply` needs `RUNPOOL_POOLS_FILE` or `--file` too, or it reads the real one and plans against real GitHub targets. `RUNPOOL_LOG_DIR` too, or the log lands in a real installation's. `CONTRIBUTING.md` has the full isolated invocation.
+
+**`register`, `set-count`, `reregister` and `remove` talk to the real GitHub API and real runners.** None has a dry-run and there is nowhere sensible to add one, because the work *is* the API call. Verify destructive changes against a throwaway private repository, never while a job is in flight — the tool refuses on purpose, and forcing past that kills live jobs.
+
+**`apply --dry-run` is the one exception, and only for the plan.** It reads the pools file and the pool configs, prints what it would do, and calls nothing, which makes all of `lib/apply.sh` testable with no GitHub account. What it does *not* cover: visibility is checked inside `register`, which a dry run never reaches, so a `+` line is a plan and not a promise.
 
 ## The icon
 
@@ -54,47 +104,6 @@ rsvg-convert -w 1024 -h 1024 assets/icon.svg -o assets/icon@1024.png
 
 The background is transparent and there are no baked-in rounded corners, so the mark works on light and dark and is never double-rounded by anything that masks it.
 
-## Conventions
-
-- **Functions are prefixed `_rp_`.** Only the dispatcher in `bin/runpool` is public surface.
-- **`set -uo pipefail`, deliberately without `-e`.** Most logic branches on exit status and the failures that matter are handled with explicit `|| return`. Do not add `-e`.
-- **Sourced fragments carry `# shellcheck shell=bash`** on line one, because they have no shebang and shellcheck cannot infer the dialect otherwise.
-- **Use `>|`, not `>`.** A shell with `noclobber` set refuses to truncate an existing file, which has silently broken this tool twice: once on the activity timestamp and once on launch agent rewriting.
-- **Use `find`, not globs, over directories that may be empty.** An unmatched glob either expands to a literal or aborts the function depending on the shell.
-- **Declare every `local` once, at the top of a function.** Re-declaring inside a loop makes some shells print it as a typeset assignment, which has leaked stray lines into logs.
-- **Comments explain why.** Most of the non-obvious lines here exist because something failed in a specific way, and the comment records that failure. Preserve those; they are the reason the code looks as it does.
-
-## Configuration precedence
-
-Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **A new setting has to be added in four places in that block** — the snapshot, the restore, the `unset`, and the `export` — or it silently becomes un-overridable, or leaks a `_rp_env_*` variable, or fails to reach a child process.
-
-`RUNPOOL_POOLS_FILE` is deliberately derived from `XDG_CONFIG_HOME` rather than from `RUNPOOL_CONFIG`'s directory, so that pointing the config at `/dev/null` to isolate a test does not also move the pools file somewhere unexpected. **The corollary is that neither `RUNPOOL_CONFIG` nor `RUNPOOL_BASE` isolates it** — it has to be set on its own, or overridden per run with `apply --file`. `/dev/null` is a valid value: `apply` tests for a readable non-directory rather than a regular file, so the isolation idiom means the same thing for both settings.
-
-## Working on it
-
-```bash
-/bin/bash -n bin/runpool lib/*.sh contrib/*.sh install.sh   # parse under stock bash
-shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh install.sh
-
-# CI runs exactly that. Without shellcheck installed, Docker gives the same
-# result and leaves nothing behind — skipping the check is how CI goes red
-# unnoticed:
-docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
-  --severity=warning bin/runpool lib/*.sh contrib/*.sh install.sh
-```
-
-**Test against a scratch directory, never a real installation:**
-
-```bash
-RUNPOOL_BASE=/tmp/rp-test RUNPOOL_CONFIG=/dev/null ./bin/runpool status --json
-```
-
-**`RUNPOOL_BASE` does not move the pools file**, by the design noted under *Configuration precedence* above. Anything touching `apply` needs `RUNPOOL_POOLS_FILE` or `--file` as well, or it reads the real one and plans against real GitHub targets. `RUNPOOL_LOG_DIR` too, or the log lands in a real installation's.
-
-**Anything that registers, resizes or removes a pool talks to the real GitHub API and to real runners.** `register`, `set-count`, `reregister` and `remove` have no dry-run and there is nowhere sensible to add one, because the work *is* the API call. Verify destructive changes against a throwaway private repository, and never while a job is in flight — the tool refuses on purpose, and forcing past that kills live jobs.
-
-**`apply --dry-run` is the one exception, and only for the plan.** It reads the pools file and the pool configs, prints what it would do, and calls nothing. That makes the whole of `lib/apply.sh` testable with hand-made pool configs under a scratch `RUNPOOL_BASE`, a scratch `RUNPOOL_POOLS_FILE`, and no GitHub account at all. Note what it does *not* cover: a repository's visibility is checked inside `register`, which a dry run never reaches, so a `+` line is a plan and not a promise.
-
 ## Issues
 
 **Every defect found gets a GitHub issue, including one fixed in the same session.** The issue is the record of what was wrong and why the fix looks the way it does; a commit message alone is not discoverable later. Close it referencing the commit.
@@ -103,11 +112,12 @@ The pattern is already established: configuration precedence was found and fixed
 
 ## Releases
 
-1. Land the change on `main` with CI green.
-2. `git tag -a vX.Y.Z` and push the tag.
-3. `gh release create vX.Y.Z` with notes describing what changed for a user.
-4. Update the Homebrew formula in the tap repository: bump `url` to the new tag and recompute `sha256` from the release tarball.
-5. `brew audit --strict` and `brew test` against the formula before pushing it.
+1. **Bump `RUNPOOL_VERSION` in `bin/runpool`.** It is the only place the version is written, and the formula builds from a git tag, so a tag without a matching bump ships a binary that misreports itself.
+2. Land the change on `main` with CI green.
+3. `git tag -a vX.Y.Z` and push the tag.
+4. `gh release create vX.Y.Z` with notes describing what changed for a user.
+5. Update the Homebrew formula in the tap repository: bump `url` to the new tag and recompute `sha256` from the release tarball.
+6. `brew audit --strict` and `brew test` against the formula before pushing it.
 
 **The formula installs `bin/` and `lib/` together under `libexec` and symlinks only the executable into `bin`.** The executable resolves its own location, following symlinks, to find `lib/` next to itself. Installing the script directly into `bin` puts `lib/` one directory too high and breaks it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ The pattern is already established: configuration precedence was found and fixed
 5. Update the Homebrew formula in the tap repository: bump `url` to the new tag and recompute `sha256` from the release tarball.
 6. `brew audit --strict` and `brew test` against the formula before pushing it.
 
+**There is no `CHANGELOG.md`, deliberately.** The release notes on GitHub are the changelog, the README's release badge links to them, and a copy in the repo would be a second thing to forget at step 4 and a second thing to disagree with the first. Do not add one.
+
 **The formula installs `bin/` and `lib/` together under `libexec` and symlinks only the executable into `bin`.** The executable resolves its own location, following symlinks, to find `lib/` next to itself. Installing the script directly into `bin` puts `lib/` one directory too high and breaks it.
 
 ## This repository's own CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,15 @@ RunPool manages **capacity** on **one Mac**. Things that are out of scope by des
 Before opening a pull request:
 
 ```bash
-/bin/bash -n bin/runpool lib/*.sh contrib/*.sh install.sh
-shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh install.sh
+/bin/bash -n bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
+shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
 ```
 
 CI runs exactly that. If shellcheck is not installed, Docker gives the same answer and leaves nothing behind:
 
 ```bash
 docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
-  --severity=warning bin/runpool lib/*.sh contrib/*.sh install.sh
+  --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh install.sh
 ```
 
 ## Testing against a real machine

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 
 Runners wake when jobs queue and stand down when nothing has run for a while. Nothing sits in the background for a repository you are not touching, and nothing starts at login.
 
-GitHub-hosted minutes are metered and macOS bills at ten times the Linux rate, so a busy repository gets expensive quickly. Self-hosted minutes are free, but GitHub's own runner is a poor houseguest on a machine you also use: it configures exactly one runner with no concept of a pool, gives you no way to change capacity afterwards, runs forever once started, and never cleans up. **RunPool makes it behave.**
-
-There is a [Raycast extension](#raycast-extension) too.
+GitHub-hosted minutes are metered and macOS bills at ten times the Linux rate. Self-hosted minutes are free, but GitHub's own runner is a poor houseguest on a machine you also use: one runner with no concept of a pool, no way to change capacity afterwards, no standing down, and no cleaning up. **RunPool makes it behave.**
 
 ## Getting started
 
@@ -31,21 +29,19 @@ jobs:
     runs-on: [self-hosted, acme]
 ```
 
-That is the whole setup. Better still, put the target behind a repository variable, so you can move a repo between hosted and self-hosted without editing workflows:
+That is the whole setup. Better still, put the target behind a repository variable, so a repo moves between hosted and self-hosted without editing workflows:
 
 ```yaml
 runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 ```
 
-The tap is [aicayzer/homebrew-tap](https://github.com/aicayzer/homebrew-tap), and `brew upgrade runpool` updates it. To work from source instead, `./install.sh` symlinks `runpool` onto your PATH from wherever you cloned it, so `git pull` is the update.
+`brew upgrade runpool` updates it, from the [aicayzer/homebrew-tap](https://github.com/aicayzer/homebrew-tap) tap. To work from source instead, `./install.sh` symlinks `runpool` onto your PATH from wherever you cloned it, so `git pull` is the update.
 
 ## How it works
 
-**A pool is a set of runners bound to one GitHub scope.** GitHub offers repository, organisation and enterprise scopes and **no user-account scope**, which is the most surprising thing about self-hosted runners. An organisation shares one pool across all its repositories; a personal repository needs its own and cannot borrow an organisation's.
-
-**Capacity and routing stay separate.** A workflow's `runs-on` decides where a job lands. RunPool decides only whether the runners are up, so a workflow pointed at a pool that is down waits for it rather than quietly rerouting to a hosted runner that costs ten times as much.
-
-**Two launch agents drive everything.** A tick every 60 seconds brings up pools with queued work, stands down idle ones, and checks their registrations are still live. A clean at 04:00 prunes work directories, caches and superseded binaries, skipping any pool mid-job. Only stopped pools are polled, so active work costs no API calls at all.
+- **A pool is a set of runners bound to one GitHub scope.** GitHub offers repository, organisation and enterprise scopes and **no user-account scope**, which is the most surprising thing about self-hosted runners. An organisation shares one pool across its repositories; a personal repository needs its own and cannot borrow an organisation's.
+- **Capacity and routing stay separate.** A workflow's `runs-on` decides where a job lands. RunPool decides only whether the runners are up, so a workflow pointed at a pool that is down waits for it rather than quietly rerouting to a hosted runner that costs ten times as much.
+- **Two launch agents drive everything.** A tick every 60 seconds brings up pools with queued work, stands down idle ones, and checks their registrations are still live. A clean at 04:00 prunes work directories, caches and superseded binaries, skipping any pool mid-job. Only stopped pools are polled, so active work costs no API calls at all.
 
 The first job after a quiet spell waits about a minute for its pool to come up. Everything after that is immediate.
 
@@ -57,29 +53,32 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | `set-count <pool> N [--if-count M]` | Change a pool's runner count. `--if-count` refuses unless it is currently M |
 | `apply [--dry-run] [--file PATH]` | Reconcile the machine to a file describing its pools |
 | `up` / `down <pool>` | Bring a pool online, or stand it down |
+| `up-all` / `down-all` | The same, for every pool |
 | `status [--json] [--local]` | Local state alongside what GitHub actually sees |
 | `doctor` | Why is nothing picking this up. Reports; changes nothing |
-| `version` | Print the installed version |
 | `pools` | List registered pools |
+| `stats [--queue]` | What jobs cost, from recorded telemetry. `--queue` adds the wait before each job started |
+| `pause [pool]` / `resume [pool]` | Global kill switch, or persistent per-pool pause |
 | `reregister <pool>` | Recreate GitHub registrations, keeping the local install |
+| `rewrite-agents` | Regenerate the launch agents after changing hook settings |
 | `remove <pool>` | Deregister and delete a pool |
 | `clean [pool]` | Prune work directories, temp, diagnostics, old binaries, caches |
-| `stats [--queue]` | What jobs actually cost, from recorded telemetry. `--queue` adds the wait before each job started |
-| `pause [pool]` / `resume [pool]` | Global kill switch, or persistent per-pool pause |
 | `schedule install\|remove` | The background agents that drive everything above |
 | `migrate-storage [--dry-run]` | Move a legacy installation into macOS storage |
+| `version` | Print the installed version |
+| `help [command]` | Per-command options and guidance |
 
-**`set-count` is absolute, so a caller that reads a count and acts on it later needs `--if-count`.** A pool changed in between turns a growth into a shrink, and shrinking deregisters runners. `--if-count M` refuses unless the pool is still at M, and one resize per pool runs at a time, so two callers cannot interleave. Deregistering a runner that GitHub then keeps is reported as a failure rather than logged and passed over: a registration GitHub still holds for a runner that no longer exists attracts jobs that queue forever.
+`tick`, `autoscale` and `sweep` exist for the launch agents to call and are not normally run by hand.
 
-**`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`: one API call per pool per minute is thousands a day, and it makes a passive readout fail whenever the network does.
+Three commands earn a note beyond the table:
 
-**`doctor` answers "why is nothing picking this up" in one command.** It checks `gh` and its authentication, that GitHub still has the registrations, that the launch agents exist — including the tick agent, which nothing else looks at and without which no pool autoscales at all — and then disk headroom, config permissions and the organisation's runner-group setting. Each failure comes with what to do about it, and it exits non-zero when something is actually wrong. It reports and repairs nothing, so it is safe to run at any moment, including mid-job.
-
-`skills/runpool/` is an agent skill for *using* RunPool: wiring a repository to local CI, choosing a scope, and diagnosing a job that queues and never starts.
+- **`set-count` is absolute, so a caller that reads a count and acts on it later needs `--if-count`.** A pool changed in between turns a growth into a shrink, and shrinking deregisters runners. `--if-count M` refuses unless the pool is still at M, and one resize per pool runs at a time so two callers cannot interleave. A runner deregistered locally that GitHub still holds is reported as a failure, not logged and passed over: a stale registration attracts jobs that then queue forever.
+- **`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`, since one API call per pool per minute is thousands a day and makes a passive readout fail whenever the network does.
+- **`doctor` answers "why is nothing picking this up" in one command.** It checks `gh` and its authentication, that GitHub still holds the registrations, that the launch agents exist, and then disk headroom, config permissions and the organisation's runner-group setting. Each failure comes with what to do about it, and it exits non-zero when something is actually wrong. It repairs nothing, so it is safe at any moment including mid-job.
 
 ## Describing a machine's pools
 
-`register` creates one pool from one command, which is the right way to add one pool and the wrong way to describe a machine: the setup then exists only as a sequence somebody remembers running. Put it in `~/.config/runpool/pools` instead, one pool per line, written as its `register` arguments minus the word `register`:
+`register` is right for adding one pool and wrong for describing a machine, because the setup then exists only as a sequence somebody remembers running. Put it in `~/.config/runpool/pools` instead, one pool per line, written as its `register` arguments minus the word `register`:
 
 ```
 acme  --org acme-inc --count 4 \
@@ -89,65 +88,28 @@ side  --repo me/side-project --count 1
 ```
 
 ```bash
-runpool apply --dry-run   # what would change
+runpool apply --dry-run   # prints the plan, touches nothing
 runpool apply
 ```
 
-**Reach for `--dry-run` first.** It prints the plan and touches nothing:
+The file holds no credentials and nothing machine-specific, so **a second machine gets the same pools by getting the same file.**
 
-```
-  ~ acme         org  acme-inc          count 2 -> 4; watch (none) -> acme-inc/api,acme-inc/web
-  = side         repo me/side-project   up to date (1 runner(s))
-  + build        org  acme-inc          create with 2 runner(s)
-  ? old          repo me/retired        not in the file — left alone ('runpool remove old' to delete it)
-```
+- **Reconciliation goes one way.** Pools in the file are created or adjusted; **a pool on the machine and not in the file is reported and left alone**, because a missing line is far too quiet a way to ask for deregistration. `remove` stays explicit.
+- **`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. Repository pools poll their own target and refuse the flag.
 
-A real run prints that same plan in full first, then acts on it under an `applying:` heading, so what was decided and what was done stay separate.
+`skills/runpool/` is an agent skill covering all of this in depth: wiring a repository, choosing a scope, sizing a pool, and diagnosing a job that queues and never starts.
 
-**The file is `~/.config/runpool/pools` unless you say otherwise.** `--file PATH` overrides it for one run and `RUNPOOL_POOLS_FILE` overrides it for good, the same precedence as every other setting: environment, then config file, then the default.
+## Security
 
-**A `#` comments out the line it is on and nothing else**, and a trailing `\` continues onto the next line — which then has to say something. Uncomment a multi-line pool entirely or not at all; half of one is an error naming both lines, not a pool quietly missing the other half.
+**A public repository is refused at registration**, because a pull request from an untrusted fork runs its own workflow file, which would hand any stranger a shell on your machine. `--allow-public` overrides it with a warning, so the decision is explicit rather than pushed into a forked copy of the tool. For an organisation that control is GitHub's rather than RunPool's: a runner group carries `allows_public_repositories`, it is `false` by default, and RunPool reads it and warns only if it has been turned on.
 
-**Reconciliation goes one way.** A pool in the file and not on the machine is created, a count or watch list that differs is changed, and **a pool on the machine and not in the file is reported and left alone**. Deleting a pool deregisters its runners with GitHub, and a missing line is far too quiet a way to ask for that, so `remove` stays explicit. Changing a pool's scope or target is reported as a conflict rather than applied, because the runners are registered against the old one.
+**[SECURITY.md](SECURITY.md) is the full picture**, including what a job on a runner can reach, why persistent runners are a deliberate choice, and the fork pull request setting RunPool cannot enforce for you.
 
-The file holds no credentials and nothing machine-specific, so **a second machine gets the same pools by getting the same file.** That is the point of it: `register` does not become wrong, it just stops being the thing you copy.
+## Storage
 
-**`--watch` matters for organisation pools.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched never wakes on its own. `register` takes it too, so a single pool created by hand is no worse off than one from the file; on a repo pool both refuse it, because such a pool already polls its own target.
+Required state lives in `~/Library/Application Support/runpool`, regenerable data in `~/Library/Caches/runpool`, logs in `~/Library/Logs/runpool`, and configuration under `~/.config/runpool`. `RUNPOOL_BASE`, `RUNPOOL_CACHE_DIR` and `RUNPOOL_LOG_DIR` override those roots.
 
-## Storage and migration
-
-**Required state lives in `~/Library/Application Support/runpool`.** That includes runner installations and credentials, pool definitions, pause state, generated launch agents and telemetry. **Regenerable data lives in `~/Library/Caches/runpool`**: job work trees, checked-out repositories, downloaded actions and tools, package stores, temp directories and runner downloads. Logs remain in `~/Library/Logs/runpool`; the config, pools file and generated job-hook launchers remain under `~/.config/runpool`. The launchers deliberately stay there because GitHub's runner requires an absolute hook path but does not quote Bash hook paths containing whitespace.
-
-`RUNPOOL_BASE`, `RUNPOOL_CACHE_DIR` and `RUNPOOL_LOG_DIR` can override those roots, with the usual precedence: environment, config file, then default. Existing `RUNPOOL_BASE` installations remain active until migrated, so upgrading never silently strands registrations.
-
-Preview a legacy migration first:
-
-```bash
-runpool migrate-storage --dry-run
-runpool migrate-storage
-runpool status --local
-runpool doctor
-```
-
-Migration refuses while a job is running, stops only idle runners, copies runner state into Application Support, moves reusable package stores into Caches, starts work and temp directories empty, rewrites each runner's absolute work folder and regenerates launch agents. Work output is discarded because compilers can embed its former absolute path; the untouched legacy tree remains available until you have verified the new installation. Remove it only afterwards. For a custom legacy `RUNPOOL_BASE`, use the exact `--from` and `--to` command printed by migration:
-
-```bash
-runpool migrate-storage --remove-legacy
-# Or, for a custom legacy root:
-runpool migrate-storage --from /old/runpool --to "$HOME/Library/Application Support/runpool" --remove-legacy
-```
-
-## Pausing pools
-
-**`runpool pause` and `runpool resume` remain the global controls.** Global pause stops every runner immediately and disables autoscaling. **`runpool pause <pool>` is different:** it safely stands down one idle pool and persists that pool's pause state. A paused pool remains registered, is skipped by autoscaling, and refuses `runpool up <pool>` until `runpool resume <pool>` is run. `down <pool>` remains a temporary stand-down and does not pause the pool.
-
-## Raycast extension
-
-<img src="assets/raycast.png" width="640" alt="The RunPool Raycast extension listing three runner pools">
-
-Start and stop pools, change runner counts, disable local CI and see what is running, without a terminal. An optional menu bar readout and a set of AI tools come with it.
-
-**In review for the Raycast store** ([raycast/extensions#30343](https://github.com/raycast/extensions/pull/30343)). Until it lands, run it from a clone of that branch with `npm install && npm run dev`.
+Installations predating this layout keep working until migrated. `runpool migrate-storage --dry-run` previews the move and the skill covers the rest, including how to verify before removing the old tree.
 
 ## Notifications
 
@@ -157,17 +119,23 @@ RunPool detects. It does not deliver. Set `RUNPOOL_NOTIFY_CMD` to any command re
 { "severity": "critical", "title": "Pool 'main' is not registered with GitHub", "key": "runpool/unregistered/main" }
 ```
 
-Unset, it reports nothing and works as well. `contrib/notify-webhook.sh` is a reference implementation and shows the full shape.
+Unset, it reports nothing and works as well. `contrib/notify-webhook.sh` is a reference implementation.
 
-**Only pool connectivity failures are reported**: a missing GitHub registration, or runners that are running locally but unreachable from GitHub. Machine load remains visible in job logs and structured status but is diagnostic context, not an alert. Failed workflow runs deliberately are not reported, because watching CI results should not depend on this laptop being awake.
+**Only pool connectivity failures are reported**: a missing GitHub registration, or runners running locally but unreachable from GitHub. Failed workflow runs deliberately are not, because watching CI results should not depend on this laptop being awake.
+
+## Raycast extension
+
+<img src="assets/raycast.png" width="640" alt="The RunPool Raycast extension listing three runner pools">
+
+Start and stop pools, change runner counts, disable local CI and see what is running, without a terminal. An optional menu bar readout and a set of AI tools come with it.
+
+**In review for the Raycast store** ([raycast/extensions#30343](https://github.com/raycast/extensions/pull/30343)). Until it lands, run it from a clone of that branch with `npm install && npm run dev`.
 
 ## Things worth knowing
 
-- **A public repository is refused at registration**, because a pull request from an untrusted fork runs its own workflow file, which would hand any stranger a shell on your machine. `--allow-public` overrides it with a warning, so the decision is explicit rather than pushed into a forked copy of the tool. Registration also refuses when visibility cannot be determined, rather than assuming private.
-- **For an organisation, that control is GitHub's, not RunPool's.** A runner group carries `allows_public_repositories`, it is `false` by default, and runners land in the default group, so public repos in the org do not get them. RunPool reads that setting when you register and warns only if it has been turned on. [SECURITY.md](SECURITY.md) covers the whole picture, including what RunPool deliberately does not do.
 - **A runner can look healthy while GitHub has dropped it.** GitHub prunes registrations that have not connected for a long time. The local install still starts and connects and then picks up nothing, so jobs queue forever against a pool reporting as running. That is what the `github` column in `status` is for, and `reregister` fixes it.
 - **`services:` and `container:` do not force a hosted runner.** Those two workflow keys are Linux-only, but an ordinary `docker run` inside a step works anywhere Docker does, including here.
-- **More runners is not obviously more throughput.** `runpool stats` describes what jobs cost and `runpool stats --queue` adds the wait before each one started, which is the figure that moves when capacity changes. Read it with the qualifier it prints: a wait can be a cold pool waking or a dependency that has not finished, and neither is fixed by more runners. `contrib/telemetry-join.sh` gives you the raw rows to separate them.
+- **More runners is not obviously more throughput.** `runpool stats --queue` gives the wait before each job started, which is the figure that moves when capacity changes. Read it with the qualifier it prints: a wait can be a cold pool waking or a dependency that has not finished, and neither is fixed by more runners.
 
 ## Not on a Mac?
 

--- a/bin/runpool
+++ b/bin/runpool
@@ -82,7 +82,9 @@ Commands:
   pause [pool]                  Pause every pool, or one pool persistently
   resume [pool]                 Resume every pool, or one paused pool
   schedule <install|remove>     Manage the background tick and clean agents
+  rewrite-agents                Regenerate the launch agents from current settings
   migrate-storage [options]     Move a legacy installation to macOS storage
+  version                       Print the installed version
   help [command]                display help for command
 
 Run 'runpool help <command>' for command-specific options and guidance.
@@ -132,7 +134,7 @@ HELP
     up|down)
       echo "Usage: runpool ${command} <pool>"
       ;;
-    up-all|down-all|tick|autoscale|sweep|pools|doctor|version)
+    up-all|down-all|tick|autoscale|sweep|pools|doctor|version|rewrite-agents)
       echo "Usage: runpool ${command}"
       ;;
     pause|resume)

--- a/skills/runpool/MIGRATION.md
+++ b/skills/runpool/MIGRATION.md
@@ -1,0 +1,40 @@
+# Storage migration
+
+New installations keep runner credentials, pool definitions and pause state in `~/Library/Application Support/runpool`, with work trees and per-runner caches in `~/Library/Caches/runpool` and logs in `~/Library/Logs/runpool`. Generated job-hook launchers stay under `~/.config/runpool`, whose path is safe for the runner's unquoted Bash hook invocation.
+
+**Installations predating this layout keep working until explicitly migrated**, so upgrading never silently strands registrations.
+
+## The sequence
+
+```bash
+runpool migrate-storage --dry-run
+runpool migrate-storage
+runpool status --local
+runpool doctor
+```
+
+Only after verifying the new installation:
+
+```bash
+runpool migrate-storage --remove-legacy
+```
+
+For a custom legacy `RUNPOOL_BASE`, use the exact `--from` and `--to` command that migration prints rather than composing one:
+
+```bash
+runpool migrate-storage --from /old/runpool \
+  --to "$HOME/Library/Application Support/runpool" --remove-legacy
+```
+
+## What it does, and what it deliberately discards
+
+- **It refuses while a job is running**, stopping only idle runners and preserving registrations and the legacy tree.
+- **Runner state is copied** into Application Support, and reusable package stores move into Caches.
+- **Work and temp directories start empty.** Build products can embed their former absolute path, so carrying them across would produce failures that look like code problems.
+- **Each runner's absolute work folder is rewritten** and the launch agents are regenerated.
+- **The legacy tree is retained** until `--remove-legacy` is run. Remove it only after `status --local` and `doctor` both look right.
+
+## Do not
+
+- **Do not run migration while a job is active.** RunPool refuses, and forcing past that kills live jobs.
+- **Do not remove the legacy tree in the same step as migrating.** The retention is the rollback.

--- a/skills/runpool/SIZING.md
+++ b/skills/runpool/SIZING.md
@@ -1,0 +1,42 @@
+# How many runners should this machine have
+
+Telemetry plus GitHub can answer this properly. `runpool stats` deliberately will not: it describes what jobs cost and stops there, because every analysis baked into the tool is a blind spot with a version number.
+
+## Start with queue time
+
+It is the only figure that moves when capacity changes. Duration says what a job costs and load says how contended the machine was; neither responds to another runner.
+
+```bash
+runpool stats --queue
+```
+
+Median and p90 of the wait before each job started, per `workflow / job`. It is behind a flag and not part of plain `stats` because it joins the local records to GitHub, one API call per run, where `stats` otherwise reads nothing but local files.
+
+**Never quote the number without the qualifier it prints.** A queue time conflates three different situations and only one of them is a shortage of runners. On an on-demand pool the first job after a quiet spell always shows about a minute of queue while the pool wakes, and no amount of capacity removes it.
+
+## Then go to the raw rows
+
+```bash
+contrib/telemetry-join.sh > joined.tsv
+```
+
+One row per job: duration, queue time, load at start, concurrency, and the raw created and started timestamps. Analyse that; do not trust a canned summary, `--queue` included.
+
+**The join key is `run_id` plus runner name.** The job hook records the workflow's job id (`check`) while the API reports its display name, so those never match.
+
+## Four traps, each of which has produced a confidently wrong answer
+
+- **Grouping duration by concurrency measures workload shape, not contention.** A workflow runs fast gate jobs first and fans out to heavy ones, so the heavy jobs are always the ones at peak concurrency. The buckets contain different work and comparing them is meaningless. Compare *within* a job type, always.
+- **Load is the better axis than concurrency.** Concurrency is pinned by the workflow's structure and barely varies. Load swings widely at the same concurrency depending on where sibling jobs are in their lifecycle, which gives real variation to correlate against. Note that load *at start* is a weak proxy for a job lasting several minutes.
+- **Queue time is not one thing.** A wait can be a cold pool waking, a dependency that has not finished, or no free runner. Only the last is fixed by more runners. Separate them by reconstructing, from the started and completed times, whether the pool was ever full during that job's wait. If a runner sat free throughout, more runners would not have helped.
+- **`created_at` is when the *run* was created, not when the job became runnable.** Every job in a workflow shares it, so occupancy at that instant is always zero and tells you nothing. Use the whole waiting interval.
+
+## Contention
+
+**The standard argument is that more runners is not more throughput**, because a single test job commonly forks one worker per core, so several in parallel thrash rather than run faster. Treat that as an argument, not a fact. It may hold on a given machine and it may not, and the difference is measurable.
+
+**If red runs come and go, suspect contention before suspecting the code.** Lower the count, or cap per-job worker counts in the test runner. The job hook in `contrib/` stamps machine load into every job so this is visible rather than guessed at.
+
+## The ceiling is not in the data
+
+Nothing in the record says what eight runners would do on a machine that has only ever run four. That needs changing the count and watching.

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: runpool
-description: |
-  Set up, wire and diagnose self-hosted GitHub Actions runners on macOS using runpool.
-  Use this skill when asked to move a repository's CI off GitHub-hosted runners, to run Actions
-  locally or on a Mac, to reduce Actions minutes or billing, to add or resize a runner pool,
-  or when a workflow is queued and nothing picks it up. Also use when the user mentions runpool,
-  self-hosted runners, runner pools, or `runs-on: self-hosted` on macOS.
+description: Set up, wire and diagnose self-hosted GitHub Actions runner pools on macOS with the runpool CLI. Use when moving a repository's CI off GitHub-hosted runners, running Actions on a Mac, reducing Actions minutes or billing, adding or resizing a runner pool, or when a workflow is queued and nothing picks it up. Also use when the user mentions runpool, self-hosted runners, runner pools, or `runs-on: self-hosted` on macOS.
 ---
 
 # runpool
@@ -14,19 +9,19 @@ On-demand self-hosted GitHub Actions runner pools for macOS. Pools wake when job
 
 **RunPool controls capacity, not routing.** Whether runners are running is runpool's job. Which runner a job lands on is decided by the workflow's `runs-on`. Both have to be right, and they are changed in different places.
 
+**Reference files, loaded when the task needs them:**
+
+- **[SIZING.md](SIZING.md)** — how many runners a machine should have, and the four traps that have each produced a confidently wrong answer.
+- **[MIGRATION.md](MIGRATION.md)** — moving a legacy installation into macOS storage.
+
 ## Before anything else
 
 ```bash
-command -v runpool || echo "not installed"
+command -v runpool || echo "not installed"     # brew install aicayzer/tap/runpool
+runpool version
 runpool status
-runpool doctor    # if anything looks wrong, or a job is queued and waiting
-runpool help <command>  # command-specific options and guidance
-```
-
-Not installed:
-
-```bash
-brew install aicayzer/tap/runpool
+runpool doctor            # if anything looks wrong, or a job is queued and waiting
+runpool help <command>    # per-command options
 ```
 
 RunPool needs an authenticated `gh` with admin on the target, because registering a runner requires a registration token.
@@ -45,13 +40,9 @@ runpool register <name> --repo OWNER/REPO --count 2  # a single repo
 runpool schedule install                             # once per machine
 ```
 
-**An org pool needs `--watch` or it never autoscales.** See *`--watch` is org-only and matters* below. A repo pool polls its own target and refuses the flag.
+**An org pool needs `--watch` or it never autoscales.** GitHub reports queued runs per repository and not per organisation, so an org pool with nothing watched waits for a manual `runpool up` every time. Both `register` and the pools file take it, repeated flags accumulate, and both refuse it on a repo pool because such a pool already polls its own target.
 
-**Pause is persistent when scoped to a pool.** `runpool pause <pool>` safely stands that pool down and prevents either autoscale or `runpool up <pool>` from starting it. Use `runpool resume <pool>` to clear it. Bare `pause` and `resume` remain the global controls; `down <pool>` is only a temporary stand-down.
-
-**Adding several pools, or setting up a second machine?** Describe them in a file and reconcile to it instead — see *Declaring a machine's pools* below.
-
-**2. Routing.** In the workflow, route the job:
+**2. Routing.** In the workflow:
 
 ```yaml
 runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -61,41 +52,7 @@ Then set the repository variable `CI_RUNNER` to `self-hosted`. The fallback keep
 
 **Never add an automatic fallback to hosted runners.** On macOS that silently costs ten times as much, and if the hosted allowance is exhausted it fails anyway. A job waiting for a pool that is down is the correct behaviour.
 
-## Declaring a machine's pools
-
-`~/.config/runpool/pools` describes what the machine should have, one pool per line, written as its `register` arguments minus the word `register`. `runpool apply` reconciles the machine to it.
-
-```
-acme  --org acme-inc --count 4 \
-      --watch acme-inc/api, acme-inc/web
-
-side  --repo me/side-project --count 1
-```
-
-**Another path**, in order of precedence: `runpool apply --file PATH` for one run, `RUNPOOL_POOLS_FILE` in the environment, `RUNPOOL_POOLS_FILE` in `~/.config/runpool/config`. Use `--file` when reading or checking a file that is not the machine's own.
-
-**A `#` comments out the line it is on and nothing else.** A trailing `\` continues onto the next line, and that line has to say something — so a pool commented out across several lines is uncommented entirely or not at all.
-
-```bash
-runpool apply --dry-run    # always this first
-runpool apply
-```
-
-**Always run `--dry-run` and show the user the plan before applying.** Applying registers runners with GitHub and can resize a pool downward, which deregisters real runners.
-
-Read the plan by its first character: `+` create, `~` change, `=` unchanged, `?` on the machine but not in the file, `!` conflict.
-
-- **`apply` never deletes.** A pool that is on the machine and not in the file is reported and left alone. If the user wants it gone, that is `runpool remove <pool>`, explicitly.
-- **`!` means the scope or target differs** from what the runners are registered against. `apply` will not fix that; remove the pool and apply again. Say so rather than working around it.
-- **`apply` exits non-zero on a conflict or a parse error**, and names the offending line by number. It also refuses a pools file it cannot read, rather than reading it as empty and reporting every real pool as `?`.
-- **A real run prints the whole plan first**, then acts under an `applying:` heading. Read the plan, not the interleaving.
-- **A public repository is still refused**, by `register`, at the moment the pool is actually created. A dry run does not reach that check, so a `+` line is not a promise the create will succeed.
-
-**Prefer this over a sequence of `register` commands whenever there is more than one pool, or more than one machine.** The file is the thing you copy; a remembered sequence of commands is not. `register` is still right for adding a single pool to a machine that has no such file.
-
-**`--watch` is org-only and matters.** GitHub reports queued runs per repository, not per organisation, so an org pool with nothing watched never autoscales and every job waits for a manual `runpool up`. Both `register` and the pools file take it, repeated flags accumulate, and both refuse it on a repo pool, because such a pool already polls its own target.
-
-**`--allow-public` is repo-only**, for the mirror-image reason: at organisation scope the control is GitHub's own `allows_public_repositories` on the runner group, so the flag would do nothing. Both routes refuse it there rather than accepting it silently. It is consulted only when a pool is created, so adding or removing it on an existing pool is not drift and `apply` correctly reports `=`.
+Keep publish, deploy and OIDC jobs hosted regardless: npm provenance requires it.
 
 ## Which scope
 
@@ -110,15 +67,44 @@ Read the plan by its first character: `+` create, `~` change, `=` unchanged, `?`
 
 A pull request from an untrusted fork runs its own workflow file, so a public repo on a self-hosted runner hands any stranger a shell on the machine, as the user who owns it.
 
-**`runpool register --repo` refuses a public repository**, and refuses again if it cannot determine visibility rather than assuming private. There is an `--allow-public` override that warns and proceeds. **Do not reach for it on the user's behalf.** It exists so the decision is explicit rather than made in a forked copy of the tool; suggest it only if the user has said they understand the exposure, and pair it with fork pull request approval below.
-
-**For an organisation, this is GitHub's control, not RunPool's.** The runner group setting `allows_public_repositories` defaults to `false`, and runners register into the default group, so public repos in the org do not get them. `register --org` reads that setting and warns only when it has been switched on. If it warns, the fix is in the organisation's Actions runner-group settings, not in runpool.
-
-**Private is not the same as safe.** Anyone who can fork a private repo and open a pull request, which usually means anyone with read access, can run code on the pool. Set **Settings → Actions → General → Fork pull request workflows** to require approval for outside contributors on any repository pointed at a pool. RunPool cannot enforce this and will not know whether it is set.
-
-Keep publish, deploy and OIDC jobs on hosted runners too: npm provenance requires it.
+- **`runpool register --repo` refuses a public repository**, and refuses again if it cannot determine visibility rather than assuming private. `--allow-public` warns and proceeds. **Do not reach for it on the user's behalf.** It exists so the decision is explicit rather than made in a forked copy of the tool; suggest it only if the user has said they understand the exposure.
+- **For an organisation this is GitHub's control.** The runner group setting `allows_public_repositories` defaults to `false` and runners register into the default group, so public repos in the org do not get them. `register --org` reads it and warns only when it has been switched on. If it warns, the fix is in the organisation's Actions runner-group settings, not in runpool.
+- **Private is not the same as safe.** Anyone who can fork a private repo and open a pull request, which usually means anyone with read access, can run code on the pool. Set **Settings → Actions → General → Fork pull request workflows** to require approval for outside contributors on any repository pointed at a pool. RunPool cannot enforce this and will not know whether it is set.
 
 `SECURITY.md` in the repo is the fuller statement, including why persistent runners are a deliberate choice and why JIT tokens are not used.
+
+## Declaring a machine's pools
+
+`~/.config/runpool/pools` describes what the machine should have, one pool per line, written as its `register` arguments minus the word `register`. `runpool apply` reconciles the machine to it.
+
+```
+acme  --org acme-inc --count 4 \
+      --watch acme-inc/api, acme-inc/web
+
+side  --repo me/side-project --count 1
+```
+
+```bash
+runpool apply --dry-run    # always this first
+runpool apply
+```
+
+**Always run `--dry-run` and show the user the plan before applying.** Applying registers runners with GitHub and can resize a pool downward, which deregisters real runners.
+
+Read the plan by its first character: `+` create, `~` change, `=` unchanged, `?` on the machine but not in the file, `!` conflict.
+
+- **`apply` never deletes.** A pool on the machine and not in the file is reported and left alone. If the user wants it gone, that is `runpool remove <pool>`, explicitly.
+- **`!` means the scope or target differs** from what the runners are registered against. `apply` will not fix that; remove the pool and apply again. Say so rather than working around it.
+- **`apply` exits non-zero on a conflict or a parse error**, and names the offending line by number. It refuses a pools file it cannot read rather than reading it as empty and reporting every real pool as `?`.
+- **A real run prints the whole plan first**, then acts under an `applying:` heading. Read the plan, not the interleaving.
+- **A public repository is still refused** by `register`, when the pool is actually created. A dry run does not reach that check, so a `+` line is not a promise the create will succeed.
+- **`--allow-public` is repo-only**, because at organisation scope the control is GitHub's. It is consulted only at creation, so adding or removing it on an existing pool is not drift and `apply` correctly reports `=`.
+
+**A `#` comments out the line it is on and nothing else.** A trailing `\` continues onto the next line, and that line has to say something, so a pool commented out across several lines is uncommented entirely or not at all.
+
+**Another path**, in order of precedence: `runpool apply --file PATH` for one run, `RUNPOOL_POOLS_FILE` in the environment, then in `~/.config/runpool/config`. Use `--file` when reading a file that is not the machine's own.
+
+**Prefer this over a sequence of `register` commands whenever there is more than one pool, or more than one machine.** The file is the thing you copy; a remembered sequence of commands is not.
 
 ## Diagnosing "the job is queued and nothing happens"
 
@@ -128,22 +114,20 @@ Keep publish, deploy and OIDC jobs on hosted runners too: npm provenance require
 runpool doctor
 ```
 
-It works down the whole list below in one pass, prints a remedy against each failure, and **exits non-zero when something is actually wrong**. It reports and repairs nothing, so it is safe at any moment including mid-job — and so nothing it finds is fixed until you run the command it names.
-
-What it finds, and what each finding means:
+It works down the whole list below in one pass, prints a remedy against each failure, and **exits non-zero when something is actually wrong**. It repairs nothing, so it is safe at any moment including mid-job, and nothing it finds is fixed until you run the command it names.
 
 - **the tick agent is not loaded** — nothing autoscales, so every job waits for a manual `runpool up` while every pool still reports as perfectly healthy. **This is the one failure no other command surfaces.** Fix: `runpool schedule install`.
-- **`gh` is not authenticated** — every API call fails and each caller degrades quietly rather than complaining: `status` reports GitHub as unreachable, and autoscale reads a queued count of zero and never wakes anything. Fix: `gh auth login`.
+- **`gh` is not authenticated** — every API call fails and each caller degrades quietly: `status` reports GitHub as unreachable, and autoscale reads a queued count of zero and never wakes anything. Fix: `gh auth login`.
 - **github has no runners registered** — GitHub prunes registrations after a long idle spell. The local install is untouched and looks entirely healthy, which is what makes this confusing. Fix: `runpool reregister <pool>`.
 - **started locally and none has reached github** — the runners are up and not connecting. Same fix.
 - **runpool is paused** — someone hit the kill switch. Fix: `runpool resume`.
 - **launch agents missing** — `runpool up` refuses on the first plist it cannot find. Fix: `runpool rewrite-agents`.
-- **an org pool with no watched repositories** — it never autoscales, because GitHub reports queued runs per repository rather than per organisation. Fix: give it `--watch` and `runpool apply`. See *`--watch` is org-only and matters* above.
+- **an org pool with no watched repositories** — it never autoscales. Fix: give it `--watch` and `runpool apply`.
 - **disk, config permissions, the organisation's runner-group setting** — each with its own remedy. None of these stops a job being picked up, but they are the things nothing else ever looks at.
 
 **Two situations `doctor` deliberately reports as healthy, because they are.**
 
-- **`running 0/N` with a job genuinely queued** — the tick brings a pool up within about a minute. Wait a minute before intervening; `runpool up <pool>` forces it.
+- **`running 0/N` with a job genuinely queued** — the tick brings a pool up within about a minute. Wait before intervening; `runpool up <pool>` forces it.
 - **A clean report and the job still waits** — the problem is routing, not capacity. The workflow's `runs-on` may not resolve to `self-hosted`, or its labels may not match the pool's. RunPool controls only whether the runners are up and cannot see either.
 
 ```bash
@@ -153,71 +137,26 @@ runpool status --json --local   # same shape, no GitHub call; use this on a time
 tail -50 ~/Library/Logs/runpool/runpool.log
 ```
 
-The JSON carries each pool's watched repositories and the paths to its logs, so a wrapper never has to guess either.
-
-**The root `paused` field is global; each pool has its own `paused` boolean.** Read both. A paused pool is intentional state, not an unreachable runner.
-
-## Storage migration
-
-New installations keep runner credentials, pool definitions and pause state in `~/Library/Application Support/runpool`, with work trees and per-runner caches in `~/Library/Caches/runpool`. Generated job-hook launchers stay under `~/.config/runpool`, whose path is safe for the runner's unquoted Bash hook invocation. Existing `RUNPOOL_BASE` installations remain active until explicitly migrated.
-
-```bash
-runpool migrate-storage --dry-run
-runpool migrate-storage
-runpool status --local
-runpool doctor
-```
-
-**Do not run migration while a job is active.** RunPool refuses it, preserving registrations and the legacy tree. Migrated work and temp directories start empty because build products can embed their former absolute path; reusable package stores move across. The old tree is retained after migration; remove it only after verification with `runpool migrate-storage --remove-legacy`. For a custom legacy `RUNPOOL_BASE`, use the exact `--from` and `--to` command printed by migration.
+The JSON carries each pool's watched repositories and the paths to its logs, so a wrapper never has to guess either. **The root `paused` field is global; each pool has its own `paused` boolean.** Read both: a paused pool is intentional state, not an unreachable runner.
 
 ## Capacity
 
 ```bash
 runpool set-count <pool> 4
+runpool set-count <pool> 4 --if-count 2    # refuse unless it is still at 2
 ```
 
-**The standard argument is that more runners is not more throughput**, because a single test job commonly forks one worker per core, so several in parallel thrash rather than run faster. Treat that as an argument, not a fact. It may hold on a given machine and it may not, and the difference is measurable.
+**`set-count` writes an absolute number, so anything that read the count earlier must pass `--if-count`.** Between the read and the write the pool may have moved, and a command meant to grow it then shrinks it instead, deregistering runners that setting the number back does not restore. Pass the count you read as `--if-count` and the resize is refused rather than guessed at. One resize per pool runs at a time, so two callers cannot interleave.
 
-**If red runs come and go, suspect contention before suspecting the code.** Lower the count, or cap per-job worker counts in the test runner. The job hook in `contrib/` stamps machine load into every job so this is visible rather than guessed at.
+A deregistration that fails is reported as a failure, not passed over. A registration GitHub still holds for a runner that no longer exists attracts jobs that queue forever, so if a resize reports orphaned runners, clear them before moving on.
 
 Resizing refuses while a job is running. Wait rather than forcing.
 
-## Answering "how many runners should this machine have"
+**Before changing a count, read [SIZING.md](SIZING.md).** More runners is not reliably more throughput, and the figure that answers the question is queue time rather than duration.
 
-Telemetry plus GitHub can answer this properly. `runpool stats` deliberately will not: it describes what jobs cost and stops there, because every analysis baked into the tool is a blind spot with a version number.
+## Pausing
 
-**Start with queue time, because it is the only figure that moves when capacity changes.** Duration says what a job costs and load says how contended the machine was; neither responds to another runner.
-
-```bash
-runpool stats --queue
-```
-
-Median and p90 of the wait before each job started, per `workflow / job`. It is behind a flag and not part of plain `stats` because it joins the local records to GitHub — one API call per run — and `stats` otherwise reads nothing but local files.
-
-**Never quote the number without the qualifier it prints.** A queue time conflates three different situations and only one of them is a shortage of runners; the trap is spelled out below and the command repeats it every time for that reason. On an on-demand pool the first job after a quiet spell always shows about a minute of queue while the pool wakes, and no amount of capacity removes it.
-
-**Then go to the raw rows to separate them:**
-
-```bash
-contrib/telemetry-join.sh > joined.tsv
-```
-
-One row per job: duration, queue time, load at start, concurrency, and the raw created and started timestamps. Analyse that, do not trust a canned summary — `--queue` included.
-
-**Four traps, each of which has produced a confidently wrong answer here.**
-
-- **Grouping duration by concurrency measures workload shape, not contention.** A workflow runs fast gate jobs first and fans out to heavy ones, so the heavy jobs are always the ones at peak concurrency. The buckets contain different work and comparing them is meaningless. Compare *within* a job type, always.
-- **Load is the better axis than concurrency.** Concurrency is pinned by the workflow's structure and barely varies. Load swings widely at the same concurrency depending on where sibling jobs are in their lifecycle, which gives real variation to correlate against. Note that load *at start* is a weak proxy for a job lasting several minutes.
-- **Queue time is not one thing.** A wait can be a cold pool waking, a dependency that has not finished, or no free runner. Only the last is fixed by more runners. Separate them by reconstructing, from the started and completed times, whether the pool was ever full during that job's wait. If a runner sat free throughout, more runners would not have helped.
-- **`created_at` is when the *run* was created, not when the job became runnable.** Every job in a workflow shares it, so occupancy at that instant is always zero and tells you nothing. Use the whole waiting interval.
-
-**The join key is `run_id` plus runner name.** The job hook records the workflow's job id (`check`) while the API reports its display name, so those never match.
-
-**What no observational data can give you is the ceiling.** Nothing in the record says what eight runners would do on a machine that has only ever run four. That needs changing the count and watching.
-
-## Containers
-
-**`services:` and `container:` do not force a hosted runner.** Those two workflow keys are Linux-only, but an ordinary `docker run` inside a step works anywhere Docker does, including macOS. Reach for that before accepting hosted spend.
+**`runpool pause <pool>` is persistent.** It stands that pool down safely and prevents both autoscale and a manual `runpool up` from starting it until `runpool resume <pool>`. Bare `pause` and `resume` are the global kill switch. `down <pool>` is only a temporary stand-down and does not pause anything.
 
 ## Disk
 
@@ -227,7 +166,11 @@ Persistent runners never clean up after themselves. `runpool clean` prunes work 
 
 RunPool ships with **no notifier** and works fully without one. Set `RUNPOOL_NOTIFY_CMD` to a command reading one JSON object on stdin; `contrib/notify-webhook.sh` is a reference implementation.
 
-**Do not add notification logic to runpool.** It reports only pool connectivity failures: a missing GitHub registration, or runners that are up locally but unreachable. Machine load stays in job logs and structured status as diagnostic context. Watching workflow *results* belongs to whatever receives the notifications, because that should not depend on the laptop being awake.
+**Do not add notification logic to runpool.** It reports only pool connectivity failures: a missing GitHub registration, or runners that are up locally but unreachable. Watching workflow *results* belongs to whatever receives the notifications, because that should not depend on the laptop being awake.
+
+## Containers
+
+**`services:` and `container:` do not force a hosted runner.** Those two workflow keys are Linux-only, but an ordinary `docker run` inside a step works anywhere Docker does, including macOS. Reach for that before accepting hosted spend.
 
 ## Things that will bite
 


### PR DESCRIPTION
The README carried roughly a third of its length in guidance the agent skill already held, near-verbatim: the pools file, the plan legend, `--watch`, the public-repository refusal, containers, throughput, and the migration runbook. Two copies of the same guidance is one copy that goes stale.

## What changed

- **README, 25% fewer words.** The duplicated guidance stays in the skill, which is where it is maintained. What remains is what a person needs to install the tool and not hurt themselves with it. The command table was missing `up-all`, `down-all`, `rewrite-agents` and `version`; it is now complete, with `tick`/`autoscale`/`sweep` called out as agent-driven.
- **The skill becomes a hub plus `SIZING.md` and `MIGRATION.md`**, following Anthropic's progressive-disclosure guidance. The sizing analysis and the migration runbook are each relevant in one narrow case and were being loaded into every context that touched runpool at all. `SKILL.md` is 25% lighter and the description is a single line, as the docs call for.
- **`--if-count` and `version` are documented in the skill**, which they had not been since 0.9.0.

## Gaps closed

Each of these was found by checking the docs against the code rather than by reading them:

- **`rewrite-agents` and `version` were missing from `runpool help`.** Both are in the dispatcher, and four of `doctor`'s remedies end in `fix: runpool rewrite-agents` — so the tool was telling people to run a command its own help denied existed. `help rewrite-agents` also reported an unknown command.
- **`AGENTS.md` never mentioned `tests/`.** The layout block listed every other directory, and the working notes gave shellcheck and `bash -n` but not the suites CI runs. It now also carries the rule that keeps the tests offline.
- **The release checklist omitted bumping `RUNPOOL_VERSION`** — the exact trap the constant's own comment in `bin/runpool` warns about.
- **`CONTRIBUTING.md` claimed its lint commands were "exactly what CI runs"** while omitting `tests/*.sh` from both.
- **No `CHANGELOG.md`, now written down as a decision** rather than left looking like an oversight.

## Verification

`bash -n` and `shellcheck --severity=warning` clean over the CI file set, `tests/storage-migration.sh` and `tests/set-count-guards.sh` both pass, every command in the README table resolves in the dispatcher, and every internal link and asset path exists.