### PR TITLE
feat: drain a busy pool instead of refusing to resize it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,5 @@ jobs:
         run: tests/set-count-guards.sh
       - name: watch-list staleness
         run: tests/watch-list-staleness.sh
+      - name: drain guards
+        run: tests/drain-guards.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ lib/scheduler.sh     status, doctor, autoscale, sweep, clean, schedule
 lib/notify.sh        the optional notifier hook and what triggers it
 lib/stats.sh         job durations from recorded telemetry, and queue times
                      via contrib/telemetry-join.sh
-tests/               offline test scripts, all three run by CI
+tests/               offline test scripts, all four run by CI
 contrib/             optional pieces the user opts into: job hook, webhook notifier,
                      demo status fixture
 skills/runpool/      agent skill for *using* runpool, shipped with the tool
@@ -53,6 +53,20 @@ assets/icon.svg      the icon, source of truth; PNGs are rendered from it
 - **A constant read in only one file belongs in that file.** shellcheck analyses each file independently, so one defined in `lib/common.sh` and read only in `bin/runpool` trips SC2034.
 - **Comments explain why.** Most of the non-obvious lines here exist because something failed in a specific way, and the comment records that failure. Preserve those; they are the reason the code looks as it does.
 
+## The launch agent carries behaviour, not just plumbing
+
+**Two plist keys are load-bearing and neither looks it.** `RUNNER_MANUALLY_TRAP_SIG` is what makes GitHub's `run.sh` finish its current job on SIGTERM instead of dying with it, and `ExitTimeOut` is what stops launchd sending SIGKILL twenty seconds later. Together they are the whole of `--drain`; remove either and the drain silently becomes the job-killing behaviour it exists to replace.
+
+**The consequence is that an agent already loaded is not necessarily an agent that behaves correctly.** A plist rewritten on disk changes nothing until the pool cycles. Anything depending on agent behaviour must therefore read the *loaded* environment with `launchctl print`, not the file — `_rp_agent_traps_signals` is the example, and `_rp_drain_pool` refuses per runner on the strength of it. The file on disk is what somebody intended; the loaded environment is what is true.
+
+## The reconfiguration lock
+
+**One per-pool lock covers resize and drain, and `up` and autoscale both respect it.** It was originally a resize lock; a drain needs the same exclusion for longer, so the concept widened rather than gaining a second flag to get out of step with.
+
+- **The holder writes its pid into the lock.** `_rp_set_count_locked` calls `_rp_up` at the end of its own work while still holding the lock, so a test for mere existence would deadlock every resize against itself. `_rp_resize_locked_by_other` is the predicate to use.
+- **Staleness is measured from the lock's mtime**, and a drain refreshes it every poll. So an old lock means nobody is tending it, not that the work is slow. Anything that can hold the lock for a long time must call `_rp_resize_lock_touch`.
+- **A dead holder is not an obstacle.** It left the directory behind, and the stale break in `_rp_resize_lock` is what clears it.
+
 ## Configuration precedence
 
 Environment, then config file, then built-in default. The config file uses plain assignments, so `lib/common.sh` snapshots any `RUNPOOL_*` already in the environment, sources the config, then restores the snapshot. **A new setting has to be added in four places in that block** — the snapshot, the restore, the `unset`, and the `export` — or it silently becomes un-overridable, or leaks a `_rp_env_*` variable, or fails to reach a child process.
@@ -69,6 +83,7 @@ shellcheck --severity=warning bin/runpool lib/*.sh contrib/*.sh tests/*.sh insta
 tests/storage-migration.sh
 tests/set-count-guards.sh
 tests/watch-list-staleness.sh
+tests/drain-guards.sh
 ```
 
 Without shellcheck installed, Docker gives the same result and leaves nothing behind. Skipping the check is how CI goes red unnoticed:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | Command | |
 |---|---|
 | `register <pool> --repo OWNER/REPO\|--org ORG [--count N] [--watch OWNER/REPO,...] [--allow-public]` | Create a pool and configure its runners |
-| `set-count <pool> N [--if-count M]` | Change a pool's runner count. `--if-count` refuses unless it is currently M |
+| `set-count <pool> N [--if-count M] [--drain]` | Change a pool's runner count. `--if-count` refuses unless it is currently M; `--drain` lets running jobs finish first |
 | `apply [--dry-run] [--file PATH]` | Reconcile the machine to a file describing its pools |
-| `up` / `down <pool>` | Bring a pool online, or stand it down |
+| `up` / `down <pool> [--drain\|--force]` | Bring a pool online, or stand it down. `--drain` waits for running jobs; `--force` ends them |
 | `up-all` / `down-all` | The same, for every pool |
 | `status [--json] [--local]` | Local state alongside what GitHub actually sees |
 | `doctor` | Why is nothing picking this up. Reports; changes nothing |
@@ -72,6 +72,7 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 
 Three commands earn a note beyond the table:
 
+- **A busy pool is resized with `--drain`.** Both `set-count` and `down` refuse by default while a job is running, because stopping a runner mid-job fails that job. On a pool that is serving work continuously that refusal has no way through, and the pool most likely to need resizing is the busy one. `--drain` stops the runners accepting new jobs, waits for the ones already running to finish, and then proceeds. The wait is bounded by `RUNPOOL_DRAIN_TIMEOUT`, and it reports what it is still waiting for rather than going quiet. It is opt-in because a command that silently blocks for an hour is worse than one that refuses.
 - **`set-count` is absolute, so a caller that reads a count and acts on it later needs `--if-count`.** A pool changed in between turns a growth into a shrink, and shrinking deregisters runners. `--if-count M` refuses unless the pool is still at M, and one resize per pool runs at a time so two callers cannot interleave. A runner deregistered locally that GitHub still holds is reported as a failure, not logged and passed over: a stale registration attracts jobs that then queue forever.
 - **`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`, since one API call per pool per minute is thousands a day and makes a passive readout fail whenever the network does.
 - **`doctor` answers "why is nothing picking this up" in one command.** It checks `gh` and its authentication, that GitHub still holds the registrations, that the launch agents exist, and then disk headroom, config permissions and the organisation's runner-group setting. Each failure comes with what to do about it, and it exits non-zero when something is actually wrong. It repairs nothing, so it is safe at any moment including mid-job.

--- a/bin/runpool
+++ b/bin/runpool
@@ -34,7 +34,7 @@ export RUNPOOL_SELF
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.9.0"
+RUNPOOL_VERSION="0.10.0"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"
@@ -66,7 +66,7 @@ Commands:
   set-count <pool> <n>          Change a pool's runner count
   apply [options]               Reconcile this machine with a pools file
   up <pool>                     Bring a pool online
-  down <pool>                   Stand a pool down
+  down <pool> [options]         Stand a pool down
   up-all                        Bring every pool online
   down-all                      Stand every pool down
   status [options]              Show local state and GitHub's runner state
@@ -117,6 +117,11 @@ Options:
                                 asked a question, and is now acting on the
                                 answer: without it a pool changed in between
                                 can be shrunk by a command meant to grow it.
+  --drain                       Let running jobs finish first, rather than
+                                refusing. This is how a continuously busy
+                                pool gets resized at all.
+  --timeout <seconds>           How long --drain waits before giving up
+                                (default: RUNPOOL_DRAIN_TIMEOUT, 4200)
 HELP
       ;;
     apply)
@@ -131,8 +136,25 @@ Options:
   --file <path>                 Read pools from a different file
 HELP
       ;;
-    up|down)
-      echo "Usage: runpool ${command} <pool>"
+    up)
+      echo "Usage: runpool up <pool>"
+      ;;
+    down)
+      cat <<'HELP'
+Usage: runpool down <pool> [options]
+
+Stand a pool down. Refuses by default while a job is running, because
+stopping a runner mid-job fails that job.
+
+Options:
+  --drain                       Stop accepting new jobs, wait for the ones
+                                already running to finish, then stand down.
+                                The pool stops accepting immediately; the
+                                wait is only for what was already in flight.
+  --timeout <seconds>           How long --drain waits before giving up
+                                (default: RUNPOOL_DRAIN_TIMEOUT, 4200)
+  --force                       Stop now, failing any running job
+HELP
       ;;
     up-all|down-all|tick|autoscale|sweep|pools|doctor|version|rewrite-agents)
       echo "Usage: runpool ${command}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -28,6 +28,7 @@ _rp_env_NOTIFY_CMD="${RUNPOOL_NOTIFY_CMD:-}"
 _rp_env_JOB_HOOK="${RUNPOOL_JOB_HOOK:-}"
 _rp_env_HOOK_DIR="${RUNPOOL_HOOK_DIR:-}"
 _rp_env_TELEMETRY="${RUNPOOL_TELEMETRY:-}"
+_rp_env_DRAIN_TIMEOUT="${RUNPOOL_DRAIN_TIMEOUT:-}"
 
 # 'set -a' exports everything the config assigns, which matters because a
 # notifier or job hook runs as a child process and cannot see a variable that
@@ -50,14 +51,16 @@ set +a
 [ -n "${_rp_env_JOB_HOOK}" ]    && RUNPOOL_JOB_HOOK="${_rp_env_JOB_HOOK}"
 [ -n "${_rp_env_HOOK_DIR}" ]    && RUNPOOL_HOOK_DIR="${_rp_env_HOOK_DIR}"
 [ -n "${_rp_env_TELEMETRY}" ]   && RUNPOOL_TELEMETRY="${_rp_env_TELEMETRY}"
+[ -n "${_rp_env_DRAIN_TIMEOUT}" ] && RUNPOOL_DRAIN_TIMEOUT="${_rp_env_DRAIN_TIMEOUT}"
 unset _rp_env_BASE _rp_env_CACHE_DIR _rp_env_POOLS_FILE _rp_env_LOG_DIR _rp_env_LABEL_NS \
       _rp_env_IDLE_SECS _rp_env_LOAD_WARN _rp_env_NOTIFY_CMD _rp_env_JOB_HOOK \
-      _rp_env_HOOK_DIR _rp_env_TELEMETRY
+      _rp_env_HOOK_DIR _rp_env_TELEMETRY _rp_env_DRAIN_TIMEOUT
 
 # Restored values need exporting again: the restore above is a plain assignment
 # and happens after 'set -a' was turned off.
 export RUNPOOL_BASE RUNPOOL_CACHE_DIR RUNPOOL_LOG_DIR RUNPOOL_LABEL_NS RUNPOOL_IDLE_SECS \
        RUNPOOL_LOAD_WARN RUNPOOL_NOTIFY_CMD RUNPOOL_JOB_HOOK RUNPOOL_HOOK_DIR RUNPOOL_TELEMETRY \
+       RUNPOOL_DRAIN_TIMEOUT \
        RUNPOOL_CONFIG RUNPOOL_POOLS_FILE
 
 # Required state belongs in Application Support. Runner installations carry
@@ -124,6 +127,22 @@ RUNPOOL_LABEL_NS="${RUNPOOL_LABEL_NS:-runpool}"
 # Restarting a runner is cheap and needs no re-registration, so a short grace
 # only avoids churn between rapid pushes inside one working session.
 RUNPOOL_IDLE_SECS="${RUNPOOL_IDLE_SECS:-1200}"
+
+# How long `--drain` waits for running jobs to finish before giving up.
+#
+# Derive this from the longest job the pool could serve plus the runner's own
+# teardown — not from how long jobs actually take. A workflow capping jobs at
+# `timeout-minutes: 60` and a drain bounded at exactly 60 minutes race each
+# other, and the drain loses in the case that matters: a job at 59m50s is
+# still legitimately running, GitHub has not cut it, and the drain times out
+# during its teardown. The drain would then report a failure for a job that
+# was about to finish cleanly, which is a false negative in the one code path
+# whose whole purpose is not killing work.
+#
+# So the default sits above the common 60-minute job cap rather than above
+# observed durations, which are far shorter. Do not lower it on the grounds
+# that no job takes this long; that is not what the number is for.
+RUNPOOL_DRAIN_TIMEOUT="${RUNPOOL_DRAIN_TIMEOUT:-4200}"
 
 # Load threshold exposed through structured status for consumers that want to
 # distinguish an ordinarily busy machine from exceptional contention. RunPool
@@ -290,6 +309,21 @@ _rp_busy_in() {
 
 _rp_agent_loaded() { launchctl list "$1" >/dev/null 2>&1; }
 
+# Whether the loaded agent finishes its job on SIGTERM rather than dying with
+# it. Reads the environment of the agent as launchd actually loaded it, not the
+# plist on disk: the file is what somebody intended, the loaded environment is
+# what is true. An agent loaded before this key existed keeps running without
+# it until the pool next cycles, and that is the case a drain has to refuse.
+_rp_agent_traps_signals() {
+  launchctl print "gui/$(id -u)/$1" 2>/dev/null | grep -q 'RUNNER_MANUALLY_TRAP_SIG'
+}
+
+# Is one specific runner running a job? Fixed-string, like _rp_busy_in, so a
+# base path containing regex characters cannot change what it matches.
+_rp_runner_busy() {
+  ps -Ao command= 2>/dev/null | grep -F "$1/runner-$2/" | grep -q "Runner.Worker"
+}
+
 # '>|' rather than '>': a shell with noclobber set refuses to truncate an
 # existing file, which silently stopped this timestamp updating and left the
 # idle sweep reading a frozen clock.
@@ -434,17 +468,24 @@ _rp_registration_token() {
 }
 
 # ---------------------------------------------------------------------------
-# Per-pool resize lock
+# Per-pool reconfiguration lock
 # ---------------------------------------------------------------------------
-# Two resizes of one pool must not interleave. A grow fetches the runner
-# tarball and runs config.sh once per new runner, so it can be working for
-# tens of seconds, and --if-count does not help: both callers would pass their
-# own check before either wrote a count.
+# Two reconfigurations of one pool must not interleave. A grow fetches the
+# runner tarball and runs config.sh once per new runner, and a drain waits out
+# whatever job is in flight, so either can hold the pool for a long time.
+# --if-count does not help: both callers would pass their own check before
+# either wrote a count.
 #
 # mkdir is the lock, for the reason the tick already uses it: atomic on every
-# POSIX filesystem, and macOS has no flock. The stale break keeps a resize
-# killed halfway from wedging a pool for good. Thirty minutes is far longer
-# than any real resize and short enough to recover from without a manual step.
+# POSIX filesystem, and macOS has no flock.
+#
+# The holder writes its pid inside. That is what lets `up` and autoscale
+# refuse to start a pool mid-reconfiguration without the holder blocking
+# itself when it restarts the pool at the end of its own work.
+#
+# Staleness is measured from the lock's mtime, not from when it was taken,
+# because a drain refreshes it on every poll. So a lock older than this means
+# nobody is tending it, whatever it was doing.
 RUNPOOL_RESIZE_STALE=1800
 
 _rp_resize_lock_dir() { echo "${RUNPOOL_STATE_DIR}/resize.$1.lock"; }
@@ -452,20 +493,40 @@ _rp_resize_lock_dir() { echo "${RUNPOOL_STATE_DIR}/resize.$1.lock"; }
 _rp_resize_lock() {
   local lock age; lock="$(_rp_resize_lock_dir "$1")"
   mkdir -p "${RUNPOOL_STATE_DIR}" 2>/dev/null
-  if mkdir "${lock}" 2>/dev/null; then return 0; fi
+  if mkdir "${lock}" 2>/dev/null; then echo $$ >| "${lock}/pid"; return 0; fi
 
   age=$(( $(_rp_now) - $(stat -f %m "${lock}" 2>/dev/null || echo 0) ))
   if [ "${age}" -lt "${RUNPOOL_RESIZE_STALE}" ]; then
-    _rp_err "pool '$1' is already being resized — wait for that to finish, then retry."
+    _rp_err "pool '$1' is already being reconfigured — wait for that to finish, then retry."
     return 1
   fi
-  _rp_log "resize: breaking a stale lock on '$1' (${age}s old)"
+  _rp_log "reconfigure: breaking a stale lock on '$1' (${age}s old)"
   rm -rf "${lock}"
-  mkdir "${lock}" 2>/dev/null || { _rp_err "could not lock pool '$1' for resize"; return 1; }
+  mkdir "${lock}" 2>/dev/null || { _rp_err "could not lock pool '$1' for reconfiguration"; return 1; }
+  echo $$ >| "${lock}/pid"
   return 0
 }
 
 _rp_resize_unlock() { rm -rf "$(_rp_resize_lock_dir "$1")"; }
+
+# Keep a long drain from being mistaken for an abandoned lock.
+_rp_resize_lock_touch() { touch "$(_rp_resize_lock_dir "$1")" 2>/dev/null; }
+
+# True when some OTHER live process holds the lock. Used by `up` and autoscale,
+# both of which must leave a pool alone while it is being reconfigured, and
+# both of which are also called BY the holder at the end of its own work — so
+# testing only for the lock's existence would deadlock a resize against itself.
+#
+# A dead holder is not an obstacle: it left the lock behind and the stale break
+# in _rp_resize_lock is what clears it.
+_rp_resize_locked_by_other() {
+  local lock pid; lock="$(_rp_resize_lock_dir "$1")"
+  [ -d "${lock}" ] || return 1
+  pid="$(cat "${lock}/pid" 2>/dev/null)"
+  case "${pid}" in ''|*[!0-9]*) return 1 ;; esac
+  [ "${pid}" = "$$" ] && return 1
+  kill -0 "${pid}" 2>/dev/null
+}
 
 _rp_deregister_runner() {
   local runner_dir="$1" scope="$2" target="$3" id url
@@ -529,6 +590,19 @@ WRAP
 # Agents are written outside ~/Library/LaunchAgents on purpose, so that macOS
 # never starts a runner at login. Pools come up because something asked, or
 # because the tick saw queued work.
+# RUNNER_MANUALLY_TRAP_SIG and ExitTimeOut are what make `--drain` possible,
+# and neither does anything during ordinary operation.
+#
+# GitHub's run.sh checks that variable: set, it installs `trap 'kill -INT
+# -$PID' INT TERM` and forwards SIGINT to the job's process group, which is
+# the documented finish-the-current-job-then-exit path. Unset, SIGTERM kills
+# run.sh and the job dies with it.
+#
+# `launchctl unload` sends SIGTERM and then SIGKILL once ExitTimeOut expires,
+# and the default is around twenty seconds — far shorter than any real job, so
+# the graceful path above would never get to finish. Six hours is generous
+# enough that launchd never beats a drain to it. Not 0: the man page says zero
+# means infinity and warns it can stall shutdown forever.
 _rp_write_plist() {
   local label="$1" dir="$2" cache_dir="$3" legacy_layout="$4" plist="${RUNPOOL_AGENT_DIR}/$1.plist" hook="" pnpm_dir npm_dir tmp_dir
   if [ "${legacy_layout}" = "1" ]; then
@@ -568,6 +642,8 @@ _rp_write_plist() {
     <string>${npm_dir}</string>
     <key>TMPDIR</key>
     <string>${tmp_dir}</string>
+    <key>RUNNER_MANUALLY_TRAP_SIG</key>
+    <string>1</string>
 PLIST
     if [ -n "${hook}" ]; then
       cat <<PLIST
@@ -585,6 +661,8 @@ PLIST
   <true/>
   <key>ThrottleInterval</key>
   <integer>10</integer>
+  <key>ExitTimeOut</key>
+  <integer>21600</integer>
   <key>StandardOutPath</key>
   <string>${RUNPOOL_LOG_DIR}/${label}.log</string>
   <key>StandardErrorPath</key>

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -235,11 +235,11 @@ _rp_write_pool_watch() {
 # Arguments used to be read as $1 and $2 with anything further ignored in
 # silence, which is how a mistyped flag became invisible. They are parsed
 # properly now and anything unrecognised is refused.
-_rp_set_count_usage() { echo "usage: runpool set-count <pool> <n> [--if-count <n>]"; }
+_rp_set_count_usage() { echo "usage: runpool set-count <pool> <n> [--if-count <n>] [--drain [--timeout <seconds>]]"; }
 
 _rp_set_count() {
   _rp_require gh || return 1
-  local name="" want="" expect="" rc
+  local name="" want="" expect="" drain=0 timeout="${RUNPOOL_DRAIN_TIMEOUT}" rc
   while [ $# -gt 0 ]; do
     case "$1" in
       --if-count)
@@ -247,6 +247,13 @@ _rp_set_count() {
         expect="$2"; shift 2 ;;
       --if-count=*)
         expect="${1#*=}"; shift ;;
+      --drain)
+        drain=1; shift ;;
+      --timeout)
+        [ $# -ge 2 ] || { _rp_err "--timeout needs a value ($(_rp_set_count_usage))"; return 1; }
+        timeout="$2"; shift 2 ;;
+      --timeout=*)
+        timeout="${1#*=}"; shift ;;
       -*)
         _rp_err "unknown flag: $1 ($(_rp_set_count_usage))"; return 1 ;;
       *)
@@ -265,19 +272,21 @@ _rp_set_count() {
   if [ -n "${expect}" ]; then
     _rp_valid_count "${expect}" || { _rp_err "--if-count: $(_rp_count_rule), got '${expect}'"; return 1; }
   fi
+  case "${timeout}" in ''|*[!0-9]*|0) _rp_err "--timeout: whole seconds above zero, got '${timeout}'"; return 1 ;; esac
 
   # Held across the whole resize, and released on every exit path by doing the
   # work in a separate function rather than with a trap. `apply` calls this in
   # a loop and installs traps of its own, which a trap set here would clobber.
   _rp_resize_lock "${name}" || return 1
-  _rp_set_count_locked "${name}" "${want}" "${expect}"
+  _rp_set_count_locked "${name}" "${want}" "${expect}" "${drain}" "${timeout}"
   rc=$?
   _rp_resize_unlock "${name}"
   return ${rc}
 }
 
 _rp_set_count_locked() {
-  local name="$1" want="$2" expect="$3"
+  local name="$1" want="$2" expect="$3" drain="$4" timeout="$5"
+  local was_up=0 orphaned=0 busy i runner_dir cache_dir label token runner_name tarball
   _rp_load_pool "${name}" || return 1
 
   local have="${POOL_COUNT}"
@@ -298,15 +307,23 @@ _rp_set_count_locked() {
 
   if [ "${want}" = "${have}" ]; then _rp_log "pool '${name}': already ${have} runner(s)"; return 0; fi
 
-  # Resizing either kills a live job or races a registration against one.
-  local busy; busy="$(_rp_busy_in "${POOL_DIR}")"
-  if [ "${busy}" -gt 0 ]; then
-    _rp_err "'${name}' has ${busy} job(s) running — refusing to resize. Wait, then retry."
-    return 1
+  # Read before draining. A drain stops the pool, so asking afterwards would
+  # always say it was already down and it would never be brought back up.
+  was_up=0
+  _rp_agent_loaded "$(_rp_label "${name}" 1)" && was_up=1
+
+  if [ "${drain}" = "1" ]; then
+    _rp_drain_pool "${name}" "${timeout}" || return 1
   fi
 
-  local was_up=0 orphaned=0 i runner_dir cache_dir label token runner_name tarball
-  _rp_agent_loaded "$(_rp_label "${name}" 1)" && was_up=1
+  # Resizing either kills a live job or races a registration against one. A
+  # successful drain leaves nothing busy, so this stays the single guard
+  # rather than something --drain has to be trusted to have handled.
+  busy="$(_rp_busy_in "${POOL_DIR}")"
+  if [ "${busy}" -gt 0 ]; then
+    _rp_err "'${name}' has ${busy} job(s) running — refusing to resize. Wait for them, or retry with --drain to let them finish first."
+    return 1
+  fi
 
   if [ "${want}" -gt "${have}" ]; then
     tarball="$(_rp_fetch_runner_tarball)" || return 1
@@ -674,6 +691,14 @@ _rp_up() {
   _rp_load_pool "$1" || return 1
   if _rp_paused; then _rp_err "runpool is paused — run 'runpool resume' first"; return 1; fi
   if _rp_pool_paused "$1"; then _rp_err "pool '$1' is paused — run 'runpool resume $1' first"; return 1; fi
+  # Not while another process is mid-resize or mid-drain. Restarting a pool
+  # whose runners are deliberately winding down would hand them new work and
+  # undo the drain. Scoped to another process so a resize can still bring the
+  # pool back up at the end of its own work.
+  if _rp_resize_locked_by_other "$1"; then
+    _rp_err "pool '$1' is being reconfigured — wait for that to finish, then retry."
+    return 1
+  fi
   local i label plist loaded=0
   [ -z "${RUNPOOL_JOB_HOOK:-}" ] || _rp_write_hook_wrappers || return 1
   i=1
@@ -697,13 +722,124 @@ _rp_up() {
 # nothing to explain why. Six live jobs were once lost this way. 'sweep' never
 # hits the guard because it only runs when nothing is busy; 'pause' forces
 # deliberately.
+# Which runners in the pool are mid-job, as a list for a progress line.
+_rp_busy_runner_list() {
+  local name="$1" i=1 out=""
+  while [ "${i}" -le "${POOL_COUNT}" ]; do
+    _rp_runner_busy "${POOL_DIR}" "${i}" && out="${out}${out:+, }${i}"
+    i=$(( i + 1 ))
+  done
+  echo "${out}"
+}
+
+# Stand a pool down without killing what it is running.
+#
+# Unloading IS the mechanism, not a step before it. It stops launchd
+# restarting the runner and delivers the SIGTERM that run.sh turns into a
+# graceful finish, so an idle runner exits at once and a busy one finishes its
+# job first. Either way no new work arrives, because the agent is gone.
+#
+# So this is not "wait for a quiet moment, then stop". The pool stops
+# accepting immediately and the wait is only for what was already in flight.
+# Expects the caller to hold the pool's reconfiguration lock.
+_rp_drain_pool() {
+  local name="$1" timeout="$2" i label busy waited=0 poll=5 stale="" on
+
+  # Refuse rather than guess. An agent loaded before this release has no
+  # RUNNER_MANUALLY_TRAP_SIG, so unloading it kills the job — precisely what
+  # this command exists to avoid. Checked against the loaded environment, so
+  # a pool that has already cycled since upgrading drains normally and only
+  # the runners that would actually lose work are refused.
+  i=1
+  while [ "${i}" -le "${POOL_COUNT}" ]; do
+    label="$(_rp_label "${name}" "${i}")"
+    if _rp_agent_loaded "${label}" && ! _rp_agent_traps_signals "${label}"; then
+      stale="${stale}${stale:+, }${i}"
+    fi
+    i=$(( i + 1 ))
+  done
+  if [ -n "${stale}" ]; then
+    _rp_err "cannot drain '${name}': runner(s) ${stale} were started before graceful shutdown was available and would lose their job."
+    _rp_err "fix: 'runpool rewrite-agents', then stand the pool down and up again once it is idle. It drains normally after that."
+    return 1
+  fi
+
+  _rp_log "draining '${name}': runners stopped, jobs already in flight will finish"
+  i=1
+  while [ "${i}" -le "${POOL_COUNT}" ]; do
+    label="$(_rp_label "${name}" "${i}")"
+    _rp_agent_loaded "${label}" && launchctl unload "${RUNPOOL_AGENT_DIR}/${label}.plist" 2>/dev/null
+    i=$(( i + 1 ))
+  done
+
+  while :; do
+    busy="$(_rp_busy_in "${POOL_DIR}")"
+    [ "${busy}" -eq 0 ] && break
+    if [ "${waited}" -ge "${timeout}" ]; then
+      _rp_err "'${name}' still has ${busy} job(s) running after $(( timeout / 60 ))m — no longer waiting."
+      _rp_err "The runners are already stopped and will exit as their jobs finish. Wait and retry, or 'runpool down ${name} --force' to end them now."
+      return 1
+    fi
+    # Say what it is waiting for. A bounded silent wait and a hang look
+    # identical from outside, and somebody will interrupt a drain that was
+    # half a minute from finishing.
+    if [ "$(( waited % 30 ))" = "0" ]; then
+      # Attribution is best-effort: the count comes from one ps scan and the
+      # per-runner match from another, so name the runners only when they
+      # were actually identified rather than printing an empty list.
+      on="$(_rp_busy_runner_list "${name}")"
+      _rp_log "draining '${name}': ${busy} job(s) still running${on:+ on runner(s) ${on}}, up to $(( (timeout - waited) / 60 ))m left"
+    fi
+    _rp_resize_lock_touch "${name}"
+    sleep "${poll}"
+    waited=$(( waited + poll ))
+  done
+
+  _rp_log "drained '${name}': every job finished and every runner is stopped"
+  return 0
+}
+
+_rp_down_usage() { echo "usage: runpool down <pool> [--drain [--timeout <seconds>]] [--force]"; }
+
 _rp_down() {
-  _rp_load_pool "$1" || return 1
-  local force=0 busy i label plist
-  [ "${2:-}" = "--force" ] && force=1
+  local name="" force=0 drain=0 timeout="${RUNPOOL_DRAIN_TIMEOUT}" busy i label plist rc
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --force) force=1; shift ;;
+      --drain) drain=1; shift ;;
+      --timeout)
+        [ $# -ge 2 ] || { _rp_err "--timeout needs a value ($(_rp_down_usage))"; return 1; }
+        timeout="$2"; shift 2 ;;
+      --timeout=*) timeout="${1#*=}"; shift ;;
+      -*) _rp_err "unknown flag: $1 ($(_rp_down_usage))"; return 1 ;;
+      *)
+        [ -z "${name}" ] || { _rp_err "unexpected argument: $1 ($(_rp_down_usage))"; return 1; }
+        name="$1"; shift ;;
+    esac
+  done
+  [ -n "${name}" ] || { _rp_err "$(_rp_down_usage)"; return 1; }
+  case "${timeout}" in ''|*[!0-9]*|0) _rp_err "--timeout: whole seconds above zero, got '${timeout}'"; return 1 ;; esac
+  if [ "${drain}" = "1" ] && [ "${force}" = "1" ]; then
+    _rp_err "--drain waits for jobs to finish and --force ends them now; pick one"
+    return 1
+  fi
+  _rp_load_pool "${name}" || return 1
+
+  if [ "${drain}" = "1" ]; then
+    # Held for the same reason a resize holds it: autoscale must not restart
+    # the pool while its runners are winding down.
+    _rp_resize_lock "${name}" || return 1
+    _rp_drain_pool "${name}" "${timeout}"; rc=$?
+    _rp_resize_unlock "${name}"
+    [ "${rc}" = "0" ] || return "${rc}"
+    _rp_log "Stopped pool '${name}'. Runners remain registered."
+    return 0
+  fi
+
+  set -- "${name}"
   busy="$(_rp_busy_in "${POOL_DIR}")"
   if [ "${busy}" -gt 0 ] && [ "${force}" = "0" ]; then
-    _rp_err "'$1' has ${busy} job(s) running — refusing to stand down (they would fail). Wait, or: runpool down $1 --force"
+    _rp_err "'$1' has ${busy} job(s) running — refusing to stand down (they would fail). Wait for them, or: runpool down $1 --drain (finishes them first), or --force (ends them now)"
     return 1
   fi
   i=1

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -122,7 +122,7 @@ _rp_status() {
 # is thousands a day, and it makes a passive readout fail whenever the network
 # does, which is the opposite of what a passive readout is for.
 _rp_status_json() {
-  local local_only="${1:-0}" p running busy gh reg online first=1 paused="false" pool_paused="false" wr wfirst
+  local local_only="${1:-0}" p running busy gh reg online first=1 paused="false" pool_paused="false" reconfiguring="false" wr wfirst
   _rp_paused && paused="true"
   # Machine state belongs here rather than being recomputed by every caller.
   # The load threshold is configurable, so a status consumer that derived it
@@ -148,8 +148,12 @@ _rp_status_json() {
     [ "${first}" = "1" ] || printf ','
     first=0
     _rp_pool_paused "${p}" && pool_paused="true" || pool_paused="false"
-    printf '{"name":"%s","scope":"%s","target":"%s","count":%s,"running":%s,"busy":%s,"paused":%s,"github_registered":%s,"github_online":%s,"watch":[' \
-      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${POOL_COUNT}" "${running}" "${busy}" "${pool_paused}" "${reg}" "${online}"
+    # A pool mid-resize or mid-drain reads as stopped-but-not-paused, which is
+    # indistinguishable from idle. A consumer showing a Start action would
+    # offer one that `up` is going to refuse.
+    _rp_resize_locked_by_other "${p}" && reconfiguring="true" || reconfiguring="false"
+    printf '{"name":"%s","scope":"%s","target":"%s","count":%s,"running":%s,"busy":%s,"paused":%s,"reconfiguring":%s,"github_registered":%s,"github_online":%s,"watch":[' \
+      "${p}" "${POOL_SCOPE}" "${POOL_TARGET}" "${POOL_COUNT}" "${running}" "${busy}" "${pool_paused}" "${reconfiguring}" "${reg}" "${online}"
     # An org pool serves many repositories and only its config knows which.
     # Without this a caller cannot show what a pool actually covers.
     wfirst=1
@@ -389,6 +393,18 @@ _rp_doctor() {
       fi
     fi
 
+    # The reconfiguration lock now refuses `up` and is skipped by autoscale, so
+    # one left behind by a resize or drain that was killed halfway is a pool
+    # that silently stops waking. It clears itself on the next attempt, but
+    # nothing says so until then.
+    if _rp_resize_locked_by_other "${p}"; then
+      _rp_doctor_note "${p}: being reconfigured right now (resize or drain in progress) — it will not autoscale until that finishes"
+    elif [ -d "$(_rp_resize_lock_dir "${p}")" ]; then
+      _rp_doctor_warn \
+        "${p}: a reconfiguration lock is left over from a resize or drain that did not finish, so the pool will not autoscale" \
+        "fix: it clears on the next 'runpool set-count' or 'runpool down --drain'; or remove $(_rp_resize_lock_dir "${p}")"
+    fi
+
     if [ "${gh_ok}" = "0" ]; then
       _rp_doctor_note "${p}: ${POOL_SCOPE} ${POOL_TARGET}, ${running}/${POOL_COUNT} running locally (github not checked)"
       continue
@@ -566,6 +582,10 @@ _rp_autoscale() {
   for p in $(_rp_pool_names); do
     _rp_load_pool "${p}" || continue
     _rp_pool_paused "${p}" && continue
+    # A pool mid-drain has its agents deliberately unloaded. Without this the
+    # tick sees a stopped pool with queued work and starts it straight back
+    # up, which both undoes the drain and hands the runners new jobs.
+    _rp_resize_locked_by_other "${p}" && continue
     up="$(_rp_running_in "${p}" "${POOL_COUNT}")"
     [ "${up}" -gt 0 ] && continue
     queued=0

--- a/skills/runpool/SIZING.md
+++ b/skills/runpool/SIZING.md
@@ -35,7 +35,7 @@ One row per job: duration, queue time, load at start, concurrency, and the raw c
 
 **The standard argument is that more runners is not more throughput**, because a single test job commonly forks one worker per core, so several in parallel thrash rather than run faster. Treat that as an argument, not a fact. It may hold on a given machine and it may not, and the difference is measurable.
 
-**If red runs come and go, suspect contention before suspecting the code.** Lower the count, or cap per-job worker counts in the test runner. The job hook in `contrib/` stamps machine load into every job so this is visible rather than guessed at.
+**If red runs come and go, suspect contention before suspecting the code.** Lower the count with `runpool set-count <pool> N --drain` — a contended pool is by definition a busy one, so without `--drain` the resize is refused exactly when you need it — or cap per-job worker counts in the test runner. The job hook in `contrib/` stamps machine load into every job so this is visible rather than guessed at.
 
 ## The ceiling is not in the data
 

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -145,13 +145,23 @@ The JSON carries each pool's watched repositories and the paths to its logs, so 
 ```bash
 runpool set-count <pool> 4
 runpool set-count <pool> 4 --if-count 2    # refuse unless it is still at 2
+runpool set-count <pool> 2 --drain         # let running jobs finish first
+runpool down <pool> --drain                # same, without resizing
 ```
 
 **`set-count` writes an absolute number, so anything that read the count earlier must pass `--if-count`.** Between the read and the write the pool may have moved, and a command meant to grow it then shrinks it instead, deregistering runners that setting the number back does not restore. Pass the count you read as `--if-count` and the resize is refused rather than guessed at. One resize per pool runs at a time, so two callers cannot interleave.
 
 A deregistration that fails is reported as a failure, not passed over. A registration GitHub still holds for a runner that no longer exists attracts jobs that queue forever, so if a resize reports orphaned runners, clear them before moving on.
 
-Resizing refuses while a job is running. Wait rather than forcing.
+**Resizing refuses while a job is running, and `--drain` is the way through.** Stopping a runner mid-job fails that job, so the refusal is right — but on a pool serving work continuously there is never a quiet moment, and the pool that most needs resizing is the busy one. `--drain` stops the runners accepting new work, waits for what is already running to finish, then resizes.
+
+- **It is opt-in, not the default.** A command that silently blocks for an hour is worse than one that refuses, and a blocking command is indistinguishable from a hung one.
+- **The wait is bounded** by `--timeout`, defaulting to `RUNPOOL_DRAIN_TIMEOUT` (4200s). Set that above the longest `timeout-minutes` any workflow on the pool allows, not above how long jobs actually take: a drain bounded at exactly the job cap can time out on a job GitHub was still happily running.
+- **It reports what it is waiting for** every 30 seconds. Do not interrupt it because it has gone quiet; it has not.
+- **On timeout the runners are already stopped** and will exit as their jobs finish. Retry, or `down <pool> --force` to end them now.
+- **`--drain` and `--force` are mutually exclusive.** One waits for jobs, the other ends them.
+
+**A pool upgraded to 0.10.0 but not yet restarted cannot drain**, because its loaded agents predate the graceful-shutdown setting. The drain detects this per runner and refuses rather than killing the job; the fix it names is `runpool rewrite-agents` then a down/up cycle once the pool is idle.
 
 **Before changing a count, read [SIZING.md](SIZING.md).** More runners is not reliably more throughput, and the figure that answers the question is queue time rather than duration.
 

--- a/tests/drain-guards.sh
+++ b/tests/drain-guards.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# The guards around --drain, exercised without runners, launchd or GitHub.
+#
+# Every case here is refused, or driven through a stubbed _rp_busy_in, so
+# nothing registers a runner, loads an agent or calls the API. The one thing
+# this cannot cover is whether a real runner finishes its job on SIGTERM;
+# that is verified by hand against a throwaway repository before release.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+trap 'rm -rf "${scratch_dir}"' EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass=0
+ok() { pass=$(( pass + 1 )); }
+
+base_dir="${scratch_dir}/base"
+mkdir -p "${base_dir}/pools" "${base_dir}/state" "${base_dir}/agents" \
+         "${scratch_dir}/cache" "${scratch_dir}/config" "${scratch_dir}/logs"
+
+cat >|"${base_dir}/pools/alpha.conf" <<CONF
+POOL_SCOPE="repo"
+POOL_TARGET="acme/widget"
+POOL_COUNT="2"
+POOL_DIR="${base_dir}/runners/alpha"
+POOL_CACHE_DIR="${scratch_dir}/cache/pools/alpha"
+POOL_LABELS="self-hosted,macOS,ARM64,alpha"
+CONF
+
+runpool() {
+  env RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${scratch_dir}/cache" \
+      RUNPOOL_CONFIG="${scratch_dir}/config/runpool.conf" \
+      RUNPOOL_POOLS_FILE="${scratch_dir}/config/pools" \
+      RUNPOOL_LOG_DIR="${scratch_dir}/logs" RUNPOOL_LOG="${scratch_dir}/logs/runpool.log" \
+      "${repo_dir}/bin/runpool" "$@"
+}
+
+count_now() { sed -n 's/^POOL_COUNT="\(.*\)"$/\1/p' "${base_dir}/pools/alpha.conf"; }
+
+assert_refused() {
+  local what="$1"; shift
+  local out rc
+  out=$("$@" 2>&1); rc=$?
+  [ "${rc}" -ne 0 ] || fail "${what}: exited 0, expected a refusal. Output: ${out}"
+  [ "$(count_now)" = "2" ] || fail "${what}: POOL_COUNT changed to $(count_now)"
+  ok
+  echo "${out}"
+}
+
+# --- argument handling --------------------------------------------------------
+# --timeout is a duration, so anything that is not a positive whole number of
+# seconds has to be refused rather than silently becoming zero and turning a
+# drain into an immediate give-up.
+assert_refused "set-count --timeout with no value"  runpool set-count alpha 1 --drain --timeout >/dev/null
+assert_refused "set-count --timeout non-numeric"    runpool set-count alpha 1 --drain --timeout abc >/dev/null
+assert_refused "set-count --timeout zero"           runpool set-count alpha 1 --drain --timeout 0 >/dev/null
+assert_refused "down --timeout with no value"       runpool down alpha --drain --timeout >/dev/null
+assert_refused "down --timeout non-numeric"         runpool down alpha --drain --timeout abc >/dev/null
+assert_refused "down unknown flag"                  runpool down alpha --no-such-flag >/dev/null
+assert_refused "down trailing argument"             runpool down alpha extra >/dev/null
+assert_refused "down with no pool"                  runpool down >/dev/null
+
+# --drain waits for jobs and --force ends them. Accepting both would have to
+# silently pick one, and either choice is wrong half the time.
+out=$(assert_refused "down --drain with --force" runpool down alpha --drain --force)
+case "${out}" in
+  *"pick one"*) ok ;;
+  *) fail "down --drain --force: unhelpful message: ${out}" ;;
+esac
+
+# --- the busy refusal names the way through ------------------------------------
+# The whole point of this release: the old message told you to wait, which on a
+# continuously busy pool is not a remedy.
+grep -q -- "--drain" "${repo_dir}/lib/lifecycle.sh" || fail "lifecycle.sh no longer mentions --drain"
+for msg in "refusing to resize" "refusing to stand down"; do
+  grep -A0 "${msg}" "${repo_dir}/lib/lifecycle.sh" | grep -q -- "--drain" \
+    || fail "the '${msg}' message does not name --drain as the way through"
+  ok
+done
+
+# --- the plist carries what the drain depends on -------------------------------
+# Without these two keys a drain kills the job it is trying to protect, so they
+# are behaviour rather than formatting.
+plist_probe() (
+  export RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${scratch_dir}/cache" \
+         RUNPOOL_CONFIG=/dev/null RUNPOOL_POOLS_FILE="${scratch_dir}/config/pools" \
+         RUNPOOL_LOG_DIR="${scratch_dir}/logs" RUNPOOL_LOG="${scratch_dir}/logs/runpool.log"
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" >/dev/null 2>&1
+  _rp_write_plist "probe.label" "${base_dir}/runners/alpha/runner-1" "${scratch_dir}/cache/x" 0
+  cat "${RUNPOOL_AGENT_DIR}/probe.label.plist"
+)
+plist="$(plist_probe)" || fail "_rp_write_plist failed"
+case "${plist}" in
+  *RUNNER_MANUALLY_TRAP_SIG*) ok ;;
+  *) fail "the plist has no RUNNER_MANUALLY_TRAP_SIG, so unloading kills the job" ;;
+esac
+case "${plist}" in
+  *ExitTimeOut*) ok ;;
+  *) fail "the plist has no ExitTimeOut, so launchd SIGKILLs the job after ~20s" ;;
+esac
+# Zero means infinity and the man page warns it can stall shutdown forever.
+printf '%s\n' "${plist}" | grep -A1 ExitTimeOut | grep -q '<integer>0</integer>' \
+  && fail "ExitTimeOut is 0, which means infinity"
+ok
+
+# --- the reconfiguration lock --------------------------------------------------
+# Driven in the sourced subshell rather than a fresh `bash -c`: shell
+# functions do not survive an exec, so a spawned shell cannot see any of this.
+lock_probe() (
+  export RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${scratch_dir}/cache" \
+         RUNPOOL_CONFIG=/dev/null RUNPOOL_POOLS_FILE="${scratch_dir}/config/pools" \
+         RUNPOOL_LOG_DIR="${scratch_dir}/logs" RUNPOOL_LOG="${scratch_dir}/logs/runpool.log"
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" >/dev/null 2>&1
+  eval "$1"
+)
+
+# A holder must not block itself: _rp_set_count_locked calls _rp_up at the end
+# of its own work, while still holding the lock it took.
+lock_probe '
+  _rp_resize_lock alpha >/dev/null 2>&1 || exit 1
+  _rp_resize_locked_by_other alpha && exit 1   # own pid: not an obstacle
+  _rp_resize_unlock alpha
+  exit 0
+' || fail "the lock blocks its own holder, which would deadlock every resize"
+ok
+
+# A different, live process holding it is an obstacle. The stand-in has to be
+# a process this user owns: kill -0 against another user\'s pid fails with
+# EPERM even when it exists, so pid 1 would look dead.
+lock_probe '
+  sleep 30 & holder=$!
+  disown "${holder}" 2>/dev/null
+  mkdir -p "$(_rp_resize_lock_dir alpha)"
+  echo "${holder}" >| "$(_rp_resize_lock_dir alpha)/pid"
+  _rp_resize_locked_by_other alpha; held=$?
+  kill "${holder}" 2>/dev/null
+  _rp_resize_unlock alpha
+  exit "${held}"
+' || fail "a lock held by another live process was not detected"
+ok
+
+# A holder that died is not an obstacle: it left the directory behind and the
+# stale break is what clears it. Treating it as held would wedge the pool.
+lock_probe '
+  mkdir -p "$(_rp_resize_lock_dir alpha)"
+  echo 999999 >| "$(_rp_resize_lock_dir alpha)/pid"
+  _rp_resize_locked_by_other alpha && exit 1
+  _rp_resize_unlock alpha
+  exit 0
+' || fail "a lock left by a dead process is being treated as held"
+ok
+
+# A long drain refreshes the lock. Staleness is measured from the mtime, so
+# without the touch a drain outliving the stale window invites a second caller
+# to break its lock and start resizing underneath it.
+lock_probe '
+  lock="$(_rp_resize_lock_dir alpha)"
+  mkdir -p "${lock}"
+  touch -t 200001010000 "${lock}"
+  before=$(stat -f %m "${lock}")
+  _rp_resize_lock_touch alpha
+  after=$(stat -f %m "${lock}")
+  _rp_resize_unlock alpha
+  [ "${after}" -gt "${before}" ]
+' || fail "_rp_resize_lock_touch did not refresh the lock"
+ok
+
+# `up` refuses while another process holds the lock, which is what stops a
+# second terminal or the tick restarting a pool mid-drain.
+lock_probe '
+  . "'"${repo_dir}"'/lib/lifecycle.sh" >/dev/null 2>&1
+  sleep 30 & holder=$!
+  disown "${holder}" 2>/dev/null
+  mkdir -p "$(_rp_resize_lock_dir alpha)"
+  echo "${holder}" >| "$(_rp_resize_lock_dir alpha)/pid"
+  out=$(_rp_up alpha 2>&1); rc=$?
+  kill "${holder}" 2>/dev/null
+  _rp_resize_unlock alpha
+  [ "${rc}" = "0" ] && exit 1
+  case "${out}" in *"being reconfigured"*) exit 0 ;; *) exit 1 ;; esac
+' || fail "up did not refuse while another process held the lock"
+ok
+
+# --- the drain loop, against a stubbed busy count ------------------------------
+# _rp_busy_in is a function, so the wait can be driven without a runner. The
+# pool has no agents loaded here, so the unload pass is a no-op and the stale
+# agent check has nothing to refuse.
+drain_probe() (
+  export RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${scratch_dir}/cache" \
+         RUNPOOL_CONFIG=/dev/null RUNPOOL_POOLS_FILE="${scratch_dir}/config/pools" \
+         RUNPOOL_LOG_DIR="${scratch_dir}/logs" RUNPOOL_LOG="${scratch_dir}/logs/runpool.log"
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" >/dev/null 2>&1
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/lifecycle.sh" >/dev/null 2>&1
+  _rp_load_pool alpha
+  eval "$1"
+  _rp_drain_pool alpha "$2"
+)
+
+# Busy forever: must give up at the bound rather than waiting indefinitely.
+out=$(drain_probe '_rp_busy_in() { echo 1; }' 5 2>&1) && fail "a drain that never quiesced returned success"
+case "${out}" in
+  *"no longer waiting"*) ok ;;
+  *) fail "timed-out drain did not say so: ${out}" ;;
+esac
+# The runners are already stopped at that point, so the message has to say what
+# is still true rather than implying nothing happened.
+case "${out}" in
+  *"already stopped"*) ok ;;
+  *) fail "timed-out drain did not say the runners are already stopped: ${out}" ;;
+esac
+
+# Nothing running: returns at once.
+drain_probe '_rp_busy_in() { echo 0; }' 5 >/dev/null 2>&1 || fail "an idle pool did not drain immediately"
+ok
+
+# Busy, then quiet: the normal case.
+# The counter lives in a file, not a variable: _rp_busy_in is called inside a
+# command substitution, so anything it assigns dies with that subshell.
+out=$(drain_probe '
+  echo 0 >| "'"${scratch_dir}"'/ticks"
+  _rp_busy_in() {
+    local n; n=$(( $(cat "'"${scratch_dir}"'/ticks") + 1 ))
+    echo "${n}" >| "'"${scratch_dir}"'/ticks"
+    [ "${n}" -gt 2 ] && echo 0 || echo 1
+  }' 60 2>&1) || fail "a pool that quiesced did not drain: ${out}"
+case "${out}" in
+  *"every job finished"*) ok ;;
+  *) fail "successful drain did not report completion: ${out}" ;;
+esac
+
+echo "ok: ${pass} case(s)"

--- a/tests/set-count-guards.sh
+++ b/tests/set-count-guards.sh
@@ -83,9 +83,9 @@ assert_refused "unknown pool" nosuchpool 5 >/dev/null
 
 # --- the resize lock ----------------------------------------------------------
 mkdir -p "${base_dir}/state/resize.alpha.lock"
-out=$(assert_refused "held resize lock" alpha 5)
+out=$(assert_refused "held reconfiguration lock" alpha 5)
 case "${out}" in
-  *"already being resized"*) ;;
+  *"already being reconfigured"*) ;;
   *) fail "held lock: unhelpful message: ${out}" ;;
 esac
 
@@ -99,7 +99,7 @@ esac
 touch -t 200001010000 "${base_dir}/state/resize.alpha.lock"
 out=$(runpool set-count alpha 5 --if-count 3 2>&1)
 case "${out}" in
-  *"already being resized"*) fail "stale lock was not broken: ${out}" ;;
+  *"already being reconfigured"*) fail "stale lock was not broken: ${out}" ;;
   *"has 4 runner(s), not 3"*) ;;
   *) fail "stale lock: unexpected outcome: ${out}" ;;
 esac


### PR DESCRIPTION
Closes #53.

`set-count` and `down` refused while **any** job was running, and `down` offered only `--force`, which kills jobs. On a pool serving work continuously there was no way through: a 45-minute retry loop polling every 60 seconds never found a gap. The refusal is correct in isolation, and its effect was that the remedy is unavailable exactly when the condition it treats is present — the pool that most needs resizing is the busy one.

`--drain` stops the runners accepting new work, waits for what is already running to finish, then proceeds.

## The mechanism was already there, unused

GitHub's own `run.sh` checks `RUNNER_MANUALLY_TRAP_SIG`. Set, it installs `trap 'kill -INT -$PID' INT TERM` and forwards SIGINT to the job's process group — the documented finish-then-exit path. `launchctl unload` sends SIGTERM, so with that variable set and `ExitTimeOut` raised above launchd's ~20s default, **unloading an agent becomes a graceful stop**. Idle runners exit at once, busy ones finish their job first, and no new work arrives because the agent is gone.

So the drain is not "wait for a quiet moment, then stop". The pool stops accepting immediately and the wait is only for what was already in flight.

## Decisions worth review

- **Opt-in, not default.** A command that silently blocks for an hour is worse than one that refuses, and a blocking command is indistinguishable from a hung one. It also reports what it is waiting for every 30 seconds, so nobody interrupts a drain that was nearly done.
- **The default timeout is derived, not chosen.** 4200s sits above the common `timeout-minutes: 60` job cap rather than above observed durations, which are far shorter. A drain bounded at exactly the job cap races the job it is protecting and loses: one at 59m50s is still legitimately running, and the drain would report a failure for work about to finish cleanly. The reasoning is at the definition site so nobody lowers it later on the reasonable-looking grounds that no job takes that long.
- **The upgrade window refuses rather than guessing.** An agent loaded before this release has no `RUNNER_MANUALLY_TRAP_SIG`, so draining it kills the job. The check reads the **loaded** environment via `launchctl print`, not the plist on disk — the file is what somebody intended, the loaded environment is what is true — so it refuses per runner and a pool that has already cycled drains normally.
- **The resize lock widens into a reconfiguration lock.** A drain needs the same exclusion for longer. It now carries the holder's pid, so `up` and autoscale can refuse to restart a pool mid-drain without the holder blocking itself when it restarts the pool at the end of its own work, and a drain refreshes it so a long wait is not mistaken for an abandoned lock.

## Verification

`bash -n` and `shellcheck --severity=warning` clean; all four suites pass. `tests/drain-guards.sh` adds 23 offline cases: argument handling, the mutually-exclusive flags, both plist keys present and `ExitTimeOut` not zero, the lock's self/other/dead-holder/refresh behaviour, `up` refusing under another process's lock, and the drain loop driven through a stubbed `_rp_busy_in` for timeout, immediate and busy-then-quiet.

**Not yet done, and blocking the release rather than the review:** the end-to-end check that a real runner finishes a real job on unload. That is the one thing the suite cannot cover.