### PR TITLE
fix: doctor answers whether a drain would work

### DIFF
--- a/bin/runpool
+++ b/bin/runpool
@@ -34,7 +34,7 @@ export RUNPOOL_SELF
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.10.0"
+RUNPOOL_VERSION="0.10.1"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -226,7 +226,7 @@ _rp_doctor() {
 
   local gh_ok=1 pools=0 seen_orgs="" p running gh reg online
   local tick clean i missing avail_kb cache_avail_kb free mode other phase hook_fails
-  local all_repos unwatched
+  local all_repos unwatched drain_stale
 
   _rp_doctor_fails=0
   _rp_doctor_warns=0
@@ -391,6 +391,28 @@ _rp_doctor() {
           _rp_doctor_ok "${p}: every repository at ${POOL_TARGET} is watched"
         fi
       fi
+    fi
+
+    # "Would a drain work here?" is the question an operator has after every
+    # upgrade, and without this the only way to answer it is to attempt the
+    # very thing being checked — on a busy pool, with real jobs at stake.
+    #
+    # Reported rather than failed: a pool whose runners predate the graceful
+    # shutdown setting is running perfectly well and picking up work. Nothing
+    # is wrong until someone tries to drain it, and the drain itself refuses
+    # safely. This exists so they do not have to find out that way.
+    drain_stale=""
+    i=1
+    while [ "${i}" -le "${POOL_COUNT}" ]; do
+      if _rp_agent_loaded "$(_rp_label "${p}" "${i}")" && \
+         ! _rp_agent_traps_signals "$(_rp_label "${p}" "${i}")"; then
+        drain_stale="${drain_stale}${drain_stale:+, }${i}"
+      fi
+      i=$(( i + 1 ))
+    done
+    if [ -n "${drain_stale}" ]; then
+      _rp_doctor_note "${p}: runner(s) ${drain_stale} started before graceful shutdown was available, so '--drain' will refuse on them. They run and take work normally; only draining is affected."
+      _rp_doctor_note "${p}: fix: 'runpool rewrite-agents', then let the pool cycle — the idle sweep does this on its own, or 'runpool down ${p}' once it is idle."
     fi
 
     # The reconfiguration lock now refuses `up` and is skipped by autoscale, so

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -124,6 +124,7 @@ It works down the whole list below in one pass, prints a remedy against each fai
 - **launch agents missing** — `runpool up` refuses on the first plist it cannot find. Fix: `runpool rewrite-agents`.
 - **an org pool with no watched repositories** — it never autoscales. Fix: give it `--watch` and `runpool apply`.
 - **an org pool watching only some of its repositories** — a note rather than a failure, because a repository may legitimately route its jobs elsewhere and nothing readable tells the difference. A job queued by an unwatched one waits until a watched one happens to wake the pool. **`doctor` makes a stale list audible; it does not maintain one.** The list stays hand-maintained, so a repository added to the organisation is still a change somebody has to make here too.
+- **runner(s) started before graceful shutdown was available** — a note, not a failure. The pool runs and takes work normally; only `--drain` is affected, and it refuses safely rather than killing the job. Fix: `runpool rewrite-agents`, then let the pool cycle. **This is how to check drain readiness without attempting a drain**, which on a busy pool means risking real jobs to answer a question.
 - **disk, config permissions, the organisation's runner-group setting** — each with its own remedy. None of these stops a job being picked up, but they are the things nothing else ever looks at.
 
 **Two situations `doctor` deliberately reports as healthy, because they are.**

--- a/tests/drain-guards.sh
+++ b/tests/drain-guards.sh
@@ -233,4 +233,40 @@ case "${out}" in
   *) fail "successful drain did not report completion: ${out}" ;;
 esac
 
+# --- doctor answers "would a drain work here" ---------------------------------
+# The predicate doctor reports on. Without it the only way to find out is to
+# attempt the drain, which is the thing being checked.
+type_probe() (
+  export RUNPOOL_BASE="${base_dir}" RUNPOOL_CACHE_DIR="${scratch_dir}/cache" \
+         RUNPOOL_CONFIG=/dev/null RUNPOOL_POOLS_FILE="${scratch_dir}/config/pools" \
+         RUNPOOL_LOG_DIR="${scratch_dir}/logs" RUNPOOL_LOG="${scratch_dir}/logs/runpool.log"
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" >/dev/null 2>&1
+  eval "$1"
+)
+
+# An agent that is not loaded cannot be mid-job, so it is not reported.
+type_probe '_rp_agent_loaded() { return 1; }
+            _rp_agent_traps_signals() { return 1; }
+            _rp_agent_loaded x && exit 1
+            exit 0' || fail "an unloaded agent should not be reported as un-drainable"
+ok
+
+# The two states doctor distinguishes.
+type_probe '_rp_agent_traps_signals() { return 0; }; _rp_agent_traps_signals x' \
+  || fail "a trapping agent was not recognised"
+ok
+type_probe '_rp_agent_traps_signals() { return 1; }; _rp_agent_traps_signals x' \
+  && fail "a non-trapping agent was recognised as trapping"
+ok
+
+# doctor must report it rather than fail it: such a pool runs and takes work
+# perfectly well, and only draining is affected.
+grep -q "only draining is affected" "${repo_dir}/lib/scheduler.sh" \
+  || fail "doctor does not say that a non-drainable pool still works normally"
+ok
+grep -B4 "only draining is affected" "${repo_dir}/lib/scheduler.sh" | grep -q "_rp_doctor_note" \
+  || fail "drain readiness should be a note, not a failure"
+ok
+
 echo "ok: ${pass} case(s)"


### PR DESCRIPTION
"Would a drain refuse here?" is the question an operator has after every upgrade, and until now **the only way to answer it was to attempt the drain** — on a busy pool, with real jobs at stake. Checking the thing by doing the thing is exactly wrong when the thing is destructive if it misjudges.

`doctor` now reports, per pool, which loaded runners predate the graceful-shutdown setting:

```
INFO  marfa: runner(s) 1, 2, 3 started before graceful shutdown was available, so
      '--drain' will refuse on them. They run and take work normally; only
      draining is affected.
INFO  marfa: fix: 'runpool rewrite-agents', then let the pool cycle — the idle
      sweep does this on its own, or 'runpool down marfa' once it is idle.
```

**A note, not a failure.** Such a pool is running and taking work perfectly normally. Nothing is wrong until someone tries to drain it, and the drain refuses safely by itself. This exists so nobody has to find that out the hard way.

It reads the **loaded** agent's environment, not the plist on disk — the same distinction `_rp_drain_pool` relies on, and the one that mattered in practice at the 0.10.0 upgrade when both machines had correct plists on disk while every loaded runner still had the old behaviour.

Found immediately after releasing 0.10.0, when neither machine could be cycled and there was no read-only way to ask what state its runners were in.

Verified live against a real pool. Five new cases in `tests/drain-guards.sh` (28 total); `bash -n` and `shellcheck --severity=warning` clean, all four suites pass.