### PR TITLE
fix: bound and parallelise the queue-time join

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,5 @@ jobs:
         run: tests/watch-list-staleness.sh
       - name: drain guards
         run: tests/drain-guards.sh
+      - name: stats queue window
+        run: tests/stats-queue-window.sh

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 | `status [--json] [--local]` | Local state alongside what GitHub actually sees |
 | `doctor` | Why is nothing picking this up. Reports; changes nothing |
 | `pools` | List registered pools |
-| `stats [--queue]` | What jobs cost, from recorded telemetry. `--queue` adds the wait before each job started |
+| `stats [--queue] [--days N \| --all]` | What jobs cost, from recorded telemetry. `--queue` adds the wait before each job started, over the last 7 days unless widened |
 | `pause [pool]` / `resume [pool]` | Global kill switch, or persistent per-pool pause |
 | `reregister <pool>` | Recreate GitHub registrations, keeping the local install |
 | `rewrite-agents` | Regenerate the launch agents after changing hook settings |
@@ -73,6 +73,7 @@ The first job after a quiet spell waits about a minute for its pool to come up. 
 Three commands earn a note beyond the table:
 
 - **A busy pool is resized with `--drain`.** Both `set-count` and `down` refuse by default while a job is running, because stopping a runner mid-job fails that job. On a pool that is serving work continuously that refusal has no way through, and the pool most likely to need resizing is the busy one. `--drain` stops the runners accepting new jobs, waits for the ones already running to finish, and then proceeds. The wait is bounded by `RUNPOOL_DRAIN_TIMEOUT`, and it reports what it is still waiting for rather than going quiet. It is opt-in because a command that silently blocks for an hour is worse than one that refuses.
+- **The pools file is intent; the running pool is state.** `set-count` changes the pool and deliberately does not write the file, so the two disagree after any resize. That is the normal condition between them rather than a fault: the file records the shape you want a machine to have and is what you copy between machines, while the pool records what is running right now. `apply` is where they are reconciled, and it resolves the difference in the file's favour, so `apply --dry-run` first is not a formality. A `count 3 -> 4` line in that plan is the drift, and applying it would undo a deliberate resize.
 - **`set-count` is absolute, so a caller that reads a count and acts on it later needs `--if-count`.** A pool changed in between turns a growth into a shrink, and shrinking deregisters runners. `--if-count M` refuses unless the pool is still at M, and one resize per pool runs at a time so two callers cannot interleave. A runner deregistered locally that GitHub still holds is reported as a failure, not logged and passed over: a stale registration attracts jobs that then queue forever.
 - **`status --json --local` skips the GitHub query**, reporting those fields as `null`. The root `paused` field is the global kill switch; every pool also carries its own additive `paused` field. Anything refreshing on a timer should use `--local`, since one API call per pool per minute is thousands a day and makes a passive readout fail whenever the network does.
 - **`doctor` answers "why is nothing picking this up" in one command.** It checks `gh` and its authentication, that GitHub still holds the registrations, that the launch agents exist, and then disk headroom, config permissions and the organisation's runner-group setting. Each failure comes with what to do about it, and it exits non-zero when something is actually wrong. It repairs nothing, so it is safe at any moment including mid-job.
@@ -137,6 +138,7 @@ Start and stop pools, change runner counts, disable local CI and see what is run
 - **A runner can look healthy while GitHub has dropped it.** GitHub prunes registrations that have not connected for a long time. The local install still starts and connects and then picks up nothing, so jobs queue forever against a pool reporting as running. That is what the `github` column in `status` is for, and `reregister` fixes it.
 - **`services:` and `container:` do not force a hosted runner.** Those two workflow keys are Linux-only, but an ordinary `docker run` inside a step works anywhere Docker does, including here.
 - **More runners is not obviously more throughput.** `runpool stats --queue` gives the wait before each job started, which is the figure that moves when capacity changes. Read it with the qualifier it prints: a wait can be a cold pool waking or a dependency that has not finished, and neither is fixed by more runners.
+- **`--queue` costs one API call per run, so it covers the last 7 days by default.** A busy machine accumulates thousands of runs, and joining all of them unbounded takes longer than anyone waits. `--days N` widens or narrows the window and `--all` removes it; the join says how many runs it is fetching and marks each one off, so a long join never looks like a stuck one.
 
 ## Not on a Mac?
 

--- a/bin/runpool
+++ b/bin/runpool
@@ -34,7 +34,7 @@ export RUNPOOL_SELF
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.10.1"
+RUNPOOL_VERSION="0.10.2"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"
@@ -181,6 +181,8 @@ Show recorded job durations.
 
 Options:
   --queue                       Join records to GitHub to include queue times
+  --days N                      Window for the join, in days (default 7)
+  --all                         Join every record kept, with no window
 HELP
       ;;
     reregister|remove)

--- a/contrib/telemetry-join.sh
+++ b/contrib/telemetry-join.sh
@@ -27,12 +27,34 @@
 # whether a wait was a shortage of runners. Reconstructing that needs the
 # timestamps.
 #
-# Usage:  telemetry-join.sh [path/to/jobs.jsonl] > joined.tsv
+# One API call per run, so the run count is the cost. That cost is bounded two
+# ways: only runs inside the window are fetched, and the calls run in parallel.
+# Unbounded and serial, a year of telemetry is not slow but unfinishable, and a
+# command with no output is indistinguishable from a hung one while it happens.
+#
+# Usage:  telemetry-join.sh [path/to/jobs.jsonl] [--days N | --all] > joined.tsv
+# Env:    RUNPOOL_JOIN_JOBS   concurrent API calls (default 8)
 # Needs:  gh, authenticated. Reads GitHub; changes nothing anywhere.
 
 set -euo pipefail
 
-TELEMETRY="${1:-}"
+TELEMETRY=""
+DAYS=7
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --all)  DAYS=0 ;;
+    --days) shift; DAYS="${1:-}"
+            case "${DAYS}" in
+              ''|*[!0-9]*) echo "--days needs a whole number of days" >&2; exit 1 ;;
+            esac
+            [ "${DAYS}" -gt 0 ] || { echo "--days needs a number above zero (use --all for no limit)" >&2; exit 1; } ;;
+    --*)    echo "unknown flag: $1 (usage: telemetry-join.sh [file] [--days N | --all])" >&2; exit 1 ;;
+    *)      TELEMETRY="$1" ;;
+  esac
+  shift
+done
+
 if [ -z "${TELEMETRY}" ]; then
   TELEMETRY="$(runpool status --json --local 2>/dev/null \
     | sed -n 's/.*"telemetry":"\([^"]*\)".*/\1/p')"
@@ -75,15 +97,46 @@ awk '
   }
 ' "${TELEMETRY}" | sort > "${work}/local.tsv"
 
+# --- window: a run outside it is dropped before it can cost an API call
+if [ "${DAYS}" -gt 0 ]; then
+  cutoff=$(( $(date +%s) - DAYS * 86400 ))
+  awk -F'\t' -v c="${cutoff}" '$11 >= c' "${work}/local.tsv" > "${work}/windowed.tsv"
+  mv "${work}/windowed.tsv" "${work}/local.tsv"
+fi
+
 # --- remote side: created and started, per runner, per run
+#
+# Each worker writes its own file rather than a shared pipe: concurrent writers
+# interleave mid-line, and a torn row here would silently corrupt the join.
 awk -F'\t' '{split($1, p, "|"); print $3 "\t" p[1]}' "${work}/local.tsv" \
-  | sort -u | while IFS=$(printf '\t') read -r repo run_id; do
-  [ -n "${run_id}" ] || continue
-  gh api "repos/${repo}/actions/runs/${run_id}/jobs" --paginate \
-    --jq ".jobs[] | [\"${run_id}|\" + .runner_name,
+  | sort -u > "${work}/runs.tsv"
+total="$(grep -c . "${work}/runs.tsv" || true)"
+jobs="${RUNPOOL_JOIN_JOBS:-8}"
+
+if [ "${DAYS}" -gt 0 ]; then
+  printf 'Joining %s run(s) from the last %s day(s), %s calls at a time.\n' \
+    "${total}" "${DAYS}" "${jobs}" >&2
+else
+  printf 'Joining all %s run(s), %s calls at a time.\n' "${total}" "${jobs}" >&2
+fi
+
+mkdir -p "${work}/out"
+export JOIN_OUT="${work}/out"
+_join_fetch() {
+  gh api "repos/$1/actions/runs/$2/jobs" --paginate \
+    --jq ".jobs[] | [\"$2|\" + .runner_name,
                      (.created_at | fromdateiso8601),
-                     (.started_at | fromdateiso8601)] | @tsv" 2>/dev/null || true
-done | sort > "${work}/remote.tsv"
+                     (.started_at | fromdateiso8601)] | @tsv" \
+    > "${JOIN_OUT}/$2" 2>/dev/null || true
+  printf '.' >&2
+}
+export -f _join_fetch
+
+if [ "${total}" -gt 0 ]; then
+  xargs -P "${jobs}" -n2 bash -c '_join_fetch "$0" "$1"' < "${work}/runs.tsv"
+  printf '\n' >&2
+fi
+find "${work}/out" -type f -exec cat {} + 2>/dev/null | sort > "${work}/remote.tsv"
 
 # --- join, then keep one remote row per local job
 #

--- a/lib/stats.sh
+++ b/lib/stats.sh
@@ -82,18 +82,29 @@ _rp_stats_have_data() {
 }
 
 _rp_stats() {
-  local arg queue=0 f
-  for arg in "$@"; do
-    case "${arg}" in
+  local queue=0 f window=""
+  # --days and --all only mean anything to the join, so they imply --queue
+  # rather than being silently accepted and ignored by the local table.
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
       --queue) queue=1 ;;
-      *) _rp_err "unknown flag: ${arg} (usage: runpool stats [--queue])"; return 1 ;;
+      --all)   queue=1; window="--all" ;;
+      --days)
+        shift
+        case "${1:-}" in
+          ''|*[!0-9]*) _rp_err "--days needs a whole number of days"; return 1 ;;
+        esac
+        [ "$1" -gt 0 ] || { _rp_err "--days needs a number above zero (use --all for no limit)"; return 1; }
+        queue=1; window="--days $1" ;;
+      *) _rp_err "unknown flag: $1 (usage: runpool stats [--queue [--days N | --all]])"; return 1 ;;
     esac
+    shift
   done
   f="$(_rp_stats_file)"
   # Missing data is explained, not an error: nothing is wrong with a machine
   # that has not switched telemetry on.
   _rp_stats_have_data "${f}" || return 0
-  if [ "${queue}" = "1" ]; then _rp_stats_queue "${f}"; else _rp_stats_local "${f}"; fi
+  if [ "${queue}" = "1" ]; then _rp_stats_queue "${f}" ${window}; else _rp_stats_local "${f}"; fi
 }
 
 _rp_stats_local() {
@@ -140,6 +151,7 @@ EOF
   echo "hook cannot see:"
   echo ""
   echo "  runpool stats --queue           median and p90 queue time, per job"
+  echo "  runpool stats --queue --all     the same, over every record kept"
   echo "  contrib/telemetry-join.sh       one row per job, everything joined"
   echo ""
   echo "  records: ${f}"
@@ -164,7 +176,8 @@ EOF
 # run-level rather than job-level — and a second copy is a second place to get
 # them wrong.
 _rp_stats_queue() {
-  local f="$1" join joined rows n key median p90 runs
+  local f="$1"; shift
+  local join joined rows n key median p90 runs
   _rp_require gh || return 1
 
   # RUNPOOL_ROOT is resolved by bin/runpool, following symlinks, and is visible
@@ -176,12 +189,14 @@ _rp_stats_queue() {
     return 1
   }
 
-  echo "Joining the local records to GitHub: one API call per run, so give it a moment."
-  echo ""
+  # stderr is deliberately not swallowed: the join reports how many runs it is
+  # fetching and prints a dot per call. Without that, a command that is working
+  # and a command that is stuck look exactly the same from here.
+  #
   # The telemetry path is passed explicitly. Left to work it out, the script
   # falls back to `runpool status --json --local` and picks up whatever runpool
   # is on PATH, which is not necessarily the one being run.
-  joined="$("${join}" "${f}" 2>/dev/null)" || {
+  joined="$("${join}" "${f}" "$@")" || {
     _rp_err "the join failed — run '${join} ${f}' directly to see why"
     return 1
   }
@@ -196,8 +211,10 @@ _rp_stats_queue() {
   if [ "${n}" -eq 0 ]; then
     echo "The join produced no rows."
     echo ""
-    echo "Every record has to match a job GitHub still has, and run history is"
-    echo "kept for a limited time, so records older than that no longer join."
+    echo "The join covers the last 7 days unless told otherwise, so the first"
+    echo "thing to try is a wider window: 'runpool stats --queue --all'. Beyond"
+    echo "that, every record has to match a job GitHub still has, and run"
+    echo "history is kept for a limited time, so older records no longer join."
     echo "Run it directly to see what came back:"
     echo ""
     echo "  ${join} ${f}"

--- a/skills/runpool/SKILL.md
+++ b/skills/runpool/SKILL.md
@@ -150,6 +150,8 @@ runpool set-count <pool> 2 --drain         # let running jobs finish first
 runpool down <pool> --drain                # same, without resizing
 ```
 
+**The pools file is intent; the running pool is state.** `set-count` changes the pool and does not write the file, so they disagree after any resize. This is by design, not drift to repair: the file is the shape you want and what you copy between machines, the pool is what is running now, and `apply` reconciles them in the file's favour. Always `apply --dry-run` first and read the plan — a `count` line in it is a deliberate resize about to be undone.
+
 **`set-count` writes an absolute number, so anything that read the count earlier must pass `--if-count`.** Between the read and the write the pool may have moved, and a command meant to grow it then shrinks it instead, deregistering runners that setting the number back does not restore. Pass the count you read as `--if-count` and the resize is refused rather than guessed at. One resize per pool runs at a time, so two callers cannot interleave.
 
 A deregistration that fails is reported as a failure, not passed over. A registration GitHub still holds for a runner that no longer exists attracts jobs that queue forever, so if a resize reports orphaned runners, clear them before moving on.

--- a/tests/stats-queue-window.sh
+++ b/tests/stats-queue-window.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# The join is bounded and reports progress, or it is indistinguishable from a
+# hang. Offline: gh is stubbed, so nothing here reaches GitHub.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+base_dir="${scratch_dir}/base"
+bin_dir="${scratch_dir}/bin"
+telemetry="${base_dir}/telemetry/jobs.jsonl"
+
+cleanup() { rm -rf "${scratch_dir}"; }
+trap cleanup EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "${base_dir}/telemetry" "${bin_dir}"
+
+# A gh that answers every run with one job, and records that it was called. The
+# call count is the whole point: the window is only real if it cuts calls.
+# Only the endpoint is logged, one line per call. Logging "$*" would log the
+# --jq argument too, which spans three lines, and every call would count as
+# three.
+cat >"${bin_dir}/gh" <<'STUB'
+#!/bin/bash
+run_id=$(printf '%s\n' "$2" | sed -n 's#.*/runs/\([0-9]*\)/jobs#\1#p')
+echo "${run_id}" >> "${GH_CALLS}"
+printf '%s|runner-1\t1000\t1030\n' "${run_id}"
+STUB
+chmod +x "${bin_dir}/gh"
+
+# One run an hour old, one ten days old. That straddles both the one-day window
+# asked for explicitly below and the seven-day default, so the same pair of
+# records exercises each.
+now=$(date +%s)
+recent=$(( now - 3600 ))
+old=$(( now - 10 * 86400 ))
+
+emit() {
+  local run_id="$1" ts="$2"
+  cat >>"${telemetry}" <<JSON
+{"phase":"started","run_id":"${run_id}","job":"build","repo":"acme/widget","workflow":"CI","runner":"runner-1","concurrent":1,"load1":1.0,"cores":8,"ts":${ts}}
+{"phase":"completed","run_id":"${run_id}","job":"build","duration":60}
+JSON
+}
+emit 111 "${recent}"
+emit 222 "${old}"
+
+join_sh() {
+  env PATH="${bin_dir}:${PATH}" GH_CALLS="${scratch_dir}/calls" \
+      "${repo_dir}/contrib/telemetry-join.sh" "${telemetry}" "$@"
+}
+
+runpool() {
+  env RUNPOOL_BASE="${base_dir}" PATH="${bin_dir}:${PATH}" GH_CALLS="${scratch_dir}/calls" \
+      "${repo_dir}/bin/runpool" "$@"
+}
+
+calls() { grep -c . "${scratch_dir}/calls" 2>/dev/null || echo 0; }
+
+# --- the window actually bounds the API calls ---------------------------------
+: >"${scratch_dir}/calls"
+out=$(join_sh --days 1 2>/dev/null) || fail "--days 1 exited non-zero"
+[ "$(calls)" = "1" ] || fail "--days 1 made $(calls) call(s), expected 1"
+printf '%s\n' "${out}" | grep -q . || fail "--days 1 produced no output at all"
+
+: >"${scratch_dir}/calls"
+join_sh --all >/dev/null 2>&1 || fail "--all exited non-zero"
+[ "$(calls)" = "2" ] || fail "--all made $(calls) call(s), expected 2"
+
+# Default is a window, not everything. If this ever reads 2, the default has
+# silently become unbounded again, which is the bug this file exists for.
+: >"${scratch_dir}/calls"
+join_sh >/dev/null 2>&1 || fail "the default run exited non-zero"
+[ "$(calls)" = "1" ] || fail "the default made $(calls) call(s), expected 1 (7-day window)"
+
+# --- it says what it is doing before it does it -------------------------------
+err=$(join_sh --days 1 2>&1 >/dev/null)
+case "${err}" in
+  *"Joining 1 run"*) ;;
+  *) fail "the join did not report its run count: ${err}" ;;
+esac
+case "${err}" in
+  *"at a time"*) ;;
+  *) fail "the join did not report its concurrency: ${err}" ;;
+esac
+
+err=$(join_sh --all 2>&1 >/dev/null)
+case "${err}" in
+  *"all 2 run"*) ;;
+  *) fail "--all did not report an unbounded join: ${err}" ;;
+esac
+
+# --- flag parsing, both entry points ------------------------------------------
+assert_refused() {
+  local what="$1"; shift
+  "$@" >/dev/null 2>&1 && fail "${what}: expected a non-zero exit"
+  return 0
+}
+
+assert_refused "join --days with no value"   join_sh --days
+assert_refused "join --days abc"             join_sh --days abc
+assert_refused "join --days 0"               join_sh --days 0
+assert_refused "join unknown flag"           join_sh --bogus
+
+assert_refused "stats --days with no value"  runpool stats --days
+assert_refused "stats --days abc"            runpool stats --days abc
+assert_refused "stats --days 0"              runpool stats --days 0
+assert_refused "stats unknown flag"          runpool stats --nope
+
+# --days and --all imply --queue: they mean nothing to the local table, and
+# accepting them there would silently ignore what the caller asked for.
+out=$(runpool stats --days 1 2>&1) || fail "stats --days 1 exited non-zero"
+case "${out}" in
+  *"Queue time"*) ;;
+  *) fail "stats --days 1 did not run the join: ${out}" ;;
+esac
+
+out=$(runpool stats --all 2>&1) || fail "stats --all exited non-zero"
+case "${out}" in
+  *"Queue time"*) ;;
+  *) fail "stats --all did not run the join: ${out}" ;;
+esac
+
+echo "OK: stats queue window"


### PR DESCRIPTION
## What

`runpool stats --queue` made one serial `gh api` call per unique run, with no bound and no progress output. On this machine that was 1821 calls; killed at ten minutes, still running, having printed a single line. A command that is working and a command that is stuck looked the same.

Closes #56, closes #57.

## Changes

- **Bounded by default.** The join covers the last 7 days. `--days N` widens or narrows it, `--all` removes the limit. A run outside the window is dropped before it can cost a call.
- **Parallel.** Calls run 8 at a time (`RUNPOOL_JOIN_JOBS`). Each worker writes its own file rather than a shared pipe, because concurrent writers interleave mid-line and a torn row would silently corrupt the join.
- **Legible.** It says how many runs it is fetching and at what concurrency, then marks each one off.
- **Docs for #57.** The pools file is intent, the running pool is state, and `apply --dry-run` reconciles them. `set-count` deliberately does not write the file, so they disagree after every resize. That was already the design; it just was not written down.

## Measured

| | before | after |
|---|---|---|
| 740 runs (7-day default) | did not finish | 66s |
| 179 runs (`--days 1`) | did not finish | 19s |

## Tests

New `tests/stats-queue-window.sh`, offline with a stubbed `gh`. Covers the window actually cutting API calls, the default staying bounded, the progress reporting, and flag validation on both entry points. Verified it fails when the default is made unbounded again.

All five suites pass; `shellcheck --severity=warning` and `bash -n` clean.