### PR TITLE
fix: a launchd agent must outlive the version that installed it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,5 @@ jobs:
         run: tests/drain-guards.sh
       - name: stats queue window
         run: tests/stats-queue-window.sh
+      - name: scheduler agent path
+        run: tests/scheduler-agent-path.sh

--- a/bin/runpool
+++ b/bin/runpool
@@ -31,10 +31,19 @@ RUNPOOL_ROOT="$(dirname "${RUNPOOL_BIN_DIR}")"
 RUNPOOL_SELF="${RUNPOOL_BIN_DIR}/runpool"
 export RUNPOOL_SELF
 
+# The path to write into a launchd agent: absolute, but deliberately NOT
+# resolved through symlinks. `RUNPOOL_SELF` above follows them, which is right
+# for finding lib/ and wrong for anything persisted: a Homebrew install
+# resolves to a version-pinned Cellar directory that the next upgrade deletes,
+# leaving launchd loading an agent whose program no longer exists. That fails
+# silently, because a loaded agent still reports as loaded.
+RUNPOOL_INVOKED="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+export RUNPOOL_INVOKED
+
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.10.2"
+RUNPOOL_VERSION="0.10.3"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -182,6 +182,10 @@ _rp_now() { date +%s; }
 # at install time rather than looked up on PATH later.
 _rp_self_path() { echo "${RUNPOOL_SELF:-$0}"; }
 
+# What a launchd agent should point at. See RUNPOOL_INVOKED in bin/runpool: the
+# resolved path is version-pinned under Homebrew and disappears on upgrade.
+_rp_agent_path() { echo "${RUNPOOL_INVOKED:-${RUNPOOL_SELF:-$0}}"; }
+
 # ---------------------------------------------------------------------------
 # Pools
 # ---------------------------------------------------------------------------
@@ -308,6 +312,33 @@ _rp_busy_in() {
 }
 
 _rp_agent_loaded() { launchctl list "$1" >/dev/null 2>&1; }
+
+# The program a loaded agent actually names, read from the plist on disk.
+#
+# PlistBuddy reports its own errors on stdout rather than stderr — a missing
+# file answers "File Doesn't Exist, Will Create: ..." and a missing key answers
+# "Does Not Exist" — so redirecting stderr is not enough to tell an answer from
+# a complaint. An absolute path is the only thing worth returning.
+_rp_agent_program() {
+  local plist="${HOME}/Library/LaunchAgents/$1.plist" program
+  [ -f "${plist}" ] || return 1
+  program="$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "${plist}" 2>/dev/null)"
+  case "${program}" in
+    /*) printf '%s\n' "${program}" ;;
+    *)  return 1 ;;
+  esac
+}
+
+# Whether that program is gone. launchd reports an agent as loaded whether or
+# not the file it names still exists, so "loaded" on its own says nothing about
+# whether the thing has run since. Absent plist or unreadable key is not
+# treated as missing: the callers already distinguish not-installed.
+_rp_agent_program_missing() {
+  local program; program="$(_rp_agent_program "$1")"
+  [ -n "${program}" ] || return 1
+  [ -x "${program}" ] && return 1
+  return 0
+}
 
 # Whether the loaded agent finishes its job on SIGTERM rather than dying with
 # it. Reads the environment of the agent as launchd actually loaded it, not the

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -276,7 +276,18 @@ _rp_doctor() {
   tick="${RUNPOOL_LABEL_NS}.tick"
   clean="${RUNPOOL_LABEL_NS}.clean"
   if _rp_agent_loaded "${tick}"; then
-    _rp_doctor_ok "the tick agent is loaded: autoscale, idle standdown and health"
+    # Loaded is not the same as working. launchd keeps reporting an agent as
+    # loaded when the program it names has been deleted, and every run fails
+    # where nothing is watching. A Homebrew upgrade did exactly this: the agent
+    # held a Cellar path from the version it was installed under, that
+    # directory went away, and the machine reported a healthy scheduler while
+    # nothing autoscaled or stood down for weeks.
+    if _rp_agent_program_missing "${tick}"; then
+      _rp_doctor_fail "the tick agent is loaded but points at a program that no longer exists, so nothing autoscales or stands down while every check still reports as healthy: $(_rp_agent_program "${tick}")" \
+                      "fix: runpool schedule install   (rewrites both agents with a path that survives an upgrade)"
+    else
+      _rp_doctor_ok "the tick agent is loaded: autoscale, idle standdown and health"
+    fi
   elif [ -f "${HOME}/Library/LaunchAgents/${tick}.plist" ]; then
     _rp_doctor_fail "the tick agent is installed but not loaded, so nothing autoscales: a queued job waits for a manual 'runpool up' and every pool still reports as healthy" \
                     "fix: runpool schedule install   (rewrites and reloads it)"
@@ -285,7 +296,12 @@ _rp_doctor() {
                     "fix: runpool schedule install"
   fi
   if _rp_agent_loaded "${clean}"; then
-    _rp_doctor_ok "the clean agent is loaded: daily prune at 04:00"
+    if _rp_agent_program_missing "${clean}"; then
+      _rp_doctor_warn "the clean agent is loaded but points at a program that no longer exists, so nothing is being pruned: $(_rp_agent_program "${clean}")" \
+                      "fix: runpool schedule install"
+    else
+      _rp_doctor_ok "the clean agent is loaded: daily prune at 04:00"
+    fi
   else
     _rp_doctor_warn "the clean agent is not loaded, so work directories, diagnostics and superseded runner binaries accrue with nothing collecting them" \
                     "fix: runpool schedule install, or 'runpool clean' by hand"
@@ -905,7 +921,7 @@ PL
 
 _rp_schedule_install() {
   local bin tick clean
-  bin="$(_rp_self_path)"
+  bin="$(_rp_agent_path)"
   tick="${RUNPOOL_LABEL_NS}.tick"
   clean="${RUNPOOL_LABEL_NS}.clean"
 

--- a/tests/scheduler-agent-path.sh
+++ b/tests/scheduler-agent-path.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# A loaded launchd agent says nothing about whether its program still exists.
+# Offline: reads plist files in a scratch HOME, loads nothing, calls nothing.
+#
+# The path a plist records is verified against the running machines rather than
+# here: writing one means invoking `schedule install`, which loads agents under
+# the real label namespace, and a test that can disturb the live scheduler is
+# worse than one that covers less.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+
+cleanup() { rm -rf "${scratch_dir}"; }
+trap cleanup EXIT INT TERM
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+HOME="${scratch_dir}/home"
+export HOME
+mkdir -p "${HOME}/Library/LaunchAgents"
+
+# shellcheck source=/dev/null
+RUNPOOL_ROOT="${repo_dir}" . "${repo_dir}/lib/common.sh"
+
+write_agent() {
+  cat >"${HOME}/Library/LaunchAgents/$1.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$1</string>
+  <key>ProgramArguments</key><array><string>$2</string><string>tick</string></array>
+</dict></plist>
+PLIST
+}
+
+# --- a program that is there ---------------------------------------------------
+write_agent "probe.present" "/bin/echo"
+if _rp_agent_program_missing "probe.present"; then
+  fail "an existing program was reported as missing"
+fi
+[ "$(_rp_agent_program "probe.present")" = "/bin/echo" ] \
+  || fail "wrong program reported: $(_rp_agent_program "probe.present")"
+
+# --- a program that has been deleted -------------------------------------------
+#
+# This is the real case, exactly as it was found: an agent installed under one
+# Homebrew version keeps that version's Cellar path, and the next upgrade
+# removes the directory. launchd still reports the agent as loaded.
+gone="/opt/homebrew/Cellar/runpool/0.0.1/libexec/bin/runpool"
+write_agent "probe.gone" "${gone}"
+_rp_agent_program_missing "probe.gone" \
+  || fail "a deleted program was not reported as missing"
+[ "$(_rp_agent_program "probe.gone")" = "${gone}" ] \
+  || fail "wrong program reported: $(_rp_agent_program "probe.gone")"
+
+# --- a program that exists but is not executable --------------------------------
+touch "${scratch_dir}/not-executable"
+write_agent "probe.notexec" "${scratch_dir}/not-executable"
+_rp_agent_program_missing "probe.notexec" \
+  || fail "a non-executable program was not reported as missing"
+
+# --- no agent at all ------------------------------------------------------------
+#
+# Not installed and pointing at nothing are different faults with different
+# fixes, and doctor reports them separately. This must not claim the first is
+# the second.
+if _rp_agent_program_missing "probe.absent"; then
+  fail "an uninstalled agent was reported as having a missing program"
+fi
+
+echo "OK: scheduler agent path"


### PR DESCRIPTION
## The failure

`schedule install` wrote the **fully resolved** path of the runpool that ran it. Under Homebrew that resolves into a version-pinned Cellar directory:

```
/opt/homebrew/Cellar/runpool/0.7.0/libexec/bin/runpool
```

The next `brew upgrade` deletes that directory. launchd carries on reporting the agent as loaded, every invocation fails where nothing is watching, and the machine **autoscales nothing, stands nothing down and runs no health checks** — while `doctor` reports the scheduler as fine.

## Found in the wild

`aic-atlas` was pointing at `Cellar/runpool/0.7.0` while running 0.10.2, so it had been without a working scheduler since that upgrade. It had a runner online that nothing was ever going to stand down, and `doctor` said:

```
scheduler
  OK    the tick agent is loaded: autoscale, idle standdown and health
```

This is the exact failure shape runpool exists to prevent: a silent stop that presents as healthy.

## Changes

- **Agents record the invoked path, not the resolved one.** A Homebrew install now writes `/opt/homebrew/bin/runpool`, which survives an upgrade. `RUNPOOL_SELF` still resolves symlinks, because finding `lib/` needs the real location — the two uses genuinely differ, and conflating them was the bug.
- **`doctor` checks that a loaded agent's program still exists.** "Loaded" was never evidence that it does.

## Tests

`tests/scheduler-agent-path.sh`, offline. Covers a present program, a deleted one, a present-but-not-executable one, and an agent that was never installed — not installed and pointing at nothing are different faults with different fixes.

Writing a plist means invoking `schedule install`, which loads agents under the real label namespace, so that half is verified against the live machines rather than in CI. A test that can disturb the running scheduler is worse than one that covers less.

While writing it the test caught a bug in its own helper: PlistBuddy reports errors on **stdout**, so a missing plist answered `File Doesn't Exist, Will Create: ...` and was read as a program path. Only an absolute path is accepted now.

All six suites pass; `shellcheck --severity=warning` and `bash -n` clean.