### PR TITLE
fix: a pool that has just started is not a pool that cannot reach GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,5 @@ jobs:
         run: tests/stats-queue-window.sh
       - name: scheduler agent path
         run: tests/scheduler-agent-path.sh
+      - name: pool settling window
+        run: tests/pool-settling-window.sh

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -107,7 +107,7 @@ RUNPOOL_HOOK_DIR="${RUNPOOL_HOOK_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/runpoo
 RUNPOOL_LOG="${RUNPOOL_LOG_DIR}/runpool.log"
 RUNPOOL_ACTIVITY="${RUNPOOL_STATE_DIR}/activity"
 RUNPOOL_PAUSE_FLAG="${RUNPOOL_STATE_DIR}/paused"
-RUNPOOL_POOL_PAUSE_DIR="${RUNPOOL_STATE_DIR}/pools"
+RUNPOOL_POOL_STATE_DIR="${RUNPOOL_STATE_DIR}/pools"
 # shellcheck disable=SC2034  # read by lib/scheduler.sh
 RUNPOOL_LAST_CLEAN="${RUNPOOL_STATE_DIR}/last-clean"
 
@@ -127,6 +127,13 @@ RUNPOOL_LABEL_NS="${RUNPOOL_LABEL_NS:-runpool}"
 # Restarting a runner is cheap and needs no re-registration, so a short grace
 # only avoids churn between rapid pushes inside one working session.
 RUNPOOL_IDLE_SECS="${RUNPOOL_IDLE_SECS:-1200}"
+
+# How long after a pool starts before its runners are expected to have reached
+# GitHub. A runner authenticates and opens its long poll a second or two after
+# launchd starts it, and until that lands the pool looks exactly like a broken
+# one: agents up locally, nothing online at GitHub. Judging a pool inside that
+# window reports every healthy start as an outage.
+RUNPOOL_SETTLE_SECS="${RUNPOOL_SETTLE_SECS:-120}"
 
 # How long `--drain` waits for running jobs to finish before giving up.
 #
@@ -160,7 +167,7 @@ RUNPOOL_NOTIFY_CMD="${RUNPOOL_NOTIFY_CMD:-}"
 RUNPOOL_TELEMETRY="${RUNPOOL_TELEMETRY:-0}"
 
 mkdir -p "${RUNPOOL_POOL_DIR}" "${RUNPOOL_RUNNER_DIR}" "${RUNPOOL_AGENT_DIR}" \
-         "${RUNPOOL_STATE_DIR}" "${RUNPOOL_POOL_PAUSE_DIR}" "${RUNPOOL_CACHE_DIR}" \
+         "${RUNPOOL_STATE_DIR}" "${RUNPOOL_POOL_STATE_DIR}" "${RUNPOOL_CACHE_DIR}" \
          "${RUNPOOL_LOG_DIR}" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
@@ -361,8 +368,20 @@ _rp_runner_busy() {
 _rp_touch_activity() { _rp_now >| "${RUNPOOL_ACTIVITY}"; }
 
 _rp_paused() { [ -f "${RUNPOOL_PAUSE_FLAG}" ]; }
-_rp_pool_pause_flag() { echo "${RUNPOOL_POOL_PAUSE_DIR}/$1.paused"; }
+_rp_pool_pause_flag() { echo "${RUNPOOL_POOL_STATE_DIR}/$1.paused"; }
 _rp_pool_paused() { [ -f "$(_rp_pool_pause_flag "$1")" ]; }
+
+# When a pool was last brought up, and whether that was recent enough that
+# GitHub cannot yet be expected to have seen it. '>|' for the same noclobber
+# reason as the activity stamp above.
+_rp_pool_started_flag() { echo "${RUNPOOL_POOL_STATE_DIR}/$1.started"; }
+_rp_touch_pool_started() { _rp_now >| "$(_rp_pool_started_flag "$1")"; }
+_rp_pool_settling() {
+  local started
+  started=$(cat "$(_rp_pool_started_flag "$1")" 2>/dev/null || echo 0)
+  case "${started}" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(_rp_now) - started )) -lt "${RUNPOOL_SETTLE_SECS}" ]
+}
 
 _rp_runner_cache_dir() { echo "${POOL_CACHE_DIR}/runner-$2"; }
 _rp_runner_work_dir() {

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -677,7 +677,7 @@ _rp_migrate_storage() {
   # shellcheck disable=SC2034  # read by lib/common.sh helpers below
   RUNPOOL_STATE_DIR="${RUNPOOL_BASE}/state"
   # shellcheck disable=SC2034  # read by lib/common.sh helpers below
-  RUNPOOL_POOL_PAUSE_DIR="${RUNPOOL_STATE_DIR}/pools"
+  RUNPOOL_POOL_STATE_DIR="${RUNPOOL_STATE_DIR}/pools"
   _rp_rewrite_plists || return 1
   _rp_log "Migrated storage to ${target}. Legacy data remains at ${source}."
   _rp_log "Verify with: runpool status --local && runpool doctor"
@@ -714,6 +714,7 @@ _rp_up() {
     i=$(( i + 1 ))
   done
   _rp_touch_activity
+  _rp_touch_pool_started "$1"
   _rp_log "Started pool '$1' (${loaded} of ${POOL_COUNT} runners online)."
 }
 

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -67,27 +67,38 @@ _rp_notify() {
 # once, and 'runpool status' only surfaces it if somebody thinks to look.
 #
 # Checked at most hourly, because it costs one API call per pool.
+#
+# The judgement itself is _rp_gh_state and is deliberately not repeated here.
+# An earlier version of this function inlined its own copy of the conditions,
+# which drifted: it had no notion of a pool that has only just started, so a
+# tick that brought a pool up and then health-checked it two seconds later
+# reported a healthy start as a critical outage. Three of the four alerts this
+# check ever sent were that race.
 _rp_health_check() {
-  local now last p gh reg online
+  local now last p gh reg online running settling
   now=$(_rp_now); last=$(cat "${RUNPOOL_HEALTH_STATE}" 2>/dev/null || echo 0)
   [ $(( now - last )) -lt 3600 ] && return 0
   echo "${now}" >| "${RUNPOOL_HEALTH_STATE}"
   for p in $(_rp_pool_names); do
     _rp_load_pool "${p}" || continue
     gh="$(_rp_gh_runners)"; reg="${gh% *}"; online="${gh#* }"
-    [ "${reg}" = "?" ] && continue   # GitHub unreachable is not a pool fault
-    if [ "${reg}" = "0" ]; then
-      _rp_notify critical \
-        "Pool '${p}' is not registered with GitHub" \
-        "runpool/unregistered/${p}" \
-        "GitHub has no runners for this pool, so any job routed to it will queue forever. Registrations are pruned after a long idle period." \
-        "\"Pool\":\"${p}\",\"Target\":\"${POOL_TARGET}\",\"Fix\":\"runpool reregister ${p}\""
-    elif [ "$(_rp_running_in "${p}" "${POOL_COUNT}")" -gt 0 ] && [ "${online}" = "0" ]; then
-      _rp_notify critical \
-        "Pool '${p}' is running but not reaching GitHub" \
-        "runpool/offline/${p}" \
-        "The runners started but none has connected. Jobs will queue against a pool that looks healthy locally." \
-        "\"Pool\":\"${p}\",\"Target\":\"${POOL_TARGET}\",\"Registered\":\"${reg}\",\"Online\":\"${online}\""
-    fi
+    running="$(_rp_running_in "${p}" "${POOL_COUNT}")"
+    settling=0; _rp_pool_settling "${p}" && settling=1
+    # unreachable, starting, miscount and ok all fall through: none of them is
+    # a pool fault a person needs waking for.
+    case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}" "${settling}")" in
+      unregistered)
+        _rp_notify critical \
+          "Pool '${p}' is not registered with GitHub" \
+          "runpool/unregistered/${p}" \
+          "GitHub has no runners for this pool, so any job routed to it will queue forever. Registrations are pruned after a long idle period." \
+          "\"Pool\":\"${p}\",\"Target\":\"${POOL_TARGET}\",\"Fix\":\"runpool reregister ${p}\"" ;;
+      offline)
+        _rp_notify critical \
+          "Pool '${p}' is running but not reaching GitHub" \
+          "runpool/offline/${p}" \
+          "The runners started but none has connected. Jobs will queue against a pool that looks healthy locally." \
+          "\"Pool\":\"${p}\",\"Target\":\"${POOL_TARGET}\",\"Registered\":\"${reg}\",\"Online\":\"${online}\"" ;;
+    esac
   done
 }

--- a/lib/scheduler.sh
+++ b/lib/scheduler.sh
@@ -22,6 +22,7 @@ _rp_gh_runners() {
 #
 #   unreachable   GitHub could not be asked, so nothing here is a pool fault
 #   unregistered  GitHub has no runners at all — jobs queue forever
+#   starting      the same shape as 'offline', but the pool came up moments ago
 #   offline       runners are up locally and none has reached GitHub
 #   miscount      GitHub's count differs from what the pool expects
 #   ok
@@ -34,11 +35,17 @@ _rp_gh_runners() {
 # The order is load-bearing: '?' has to be tested before anything treats these
 # as numbers, and 'unregistered' before 'miscount', which would otherwise
 # swallow it.
+# 'starting' exists because a runner reaches GitHub a second or two after
+# launchd starts it, so for that moment a healthy pool is indistinguishable
+# from a broken one on these numbers alone. The caller passes whether the pool
+# is inside its settling window; only the age separates the two.
 #   $1 registered  $2 online  $3 running locally  $4 expected count
+#   $5 settling (1 while inside the window, 0 or absent otherwise)
 _rp_gh_state() {
   if   [ "$1" = "?" ];                       then echo unreachable
   elif [ "$1" = "0" ];                       then echo unregistered
-  elif [ "$3" -gt 0 ] && [ "$2" = "0" ];     then echo offline
+  elif [ "$3" -gt 0 ] && [ "$2" = "0" ]; then
+    if [ "${5:-0}" = "1" ]; then echo starting; else echo offline; fi
   elif [ "$1" != "$4" ];                     then echo miscount
   else                                            echo ok
   fi
@@ -59,7 +66,7 @@ _rp_running_in() {
 # cleanly, looks healthy in every local check, and picks up nothing. Reporting
 # only the local view hid exactly that for three weeks.
 _rp_status() {
-  local as_json=0 local_only=0 arg total_running=0 total_busy=0 p running busy gh reg online gh_display note warn=0
+  local as_json=0 local_only=0 arg total_running=0 total_busy=0 p running busy gh reg online gh_display note settling warn=0
   for arg in "$@"; do
     case "${arg}" in
       --json)  as_json=1 ;;
@@ -85,9 +92,11 @@ _rp_status() {
       gh="$(_rp_gh_runners)"; reg="${gh% *}"; online="${gh#* }"
       gh_display="${online}/${reg}"
       note=""
-      case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}")" in
+      settling=0; _rp_pool_settling "${p}" && settling=1
+      case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}" "${settling}")" in
         unreachable)  gh_display="unreachable" ;;
         unregistered) note="  (not registered; jobs will queue)"; warn=1 ;;
+        starting)     note="  (just started; still connecting)" ;;
         offline)      note="  (started but not connected)"; warn=1 ;;
         miscount)     note="  (pool expects ${POOL_COUNT})" ;;
       esac
@@ -224,7 +233,7 @@ _rp_doctor_fail() {
 _rp_doctor() {
   [ $# -eq 0 ] || { _rp_err "doctor takes no arguments (usage: runpool doctor)"; return 1; }
 
-  local gh_ok=1 pools=0 seen_orgs="" p running gh reg online
+  local gh_ok=1 pools=0 seen_orgs="" p running gh reg online settling
   local tick clean i missing avail_kb cache_avail_kb free mode other phase hook_fails
   local all_repos unwatched drain_stale
 
@@ -448,9 +457,12 @@ _rp_doctor() {
       continue
     fi
     gh="$(_rp_gh_runners)"; reg="${gh% *}"; online="${gh#* }"
-    case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}")" in
+    settling=0; _rp_pool_settling "${p}" && settling=1
+    case "$(_rp_gh_state "${reg}" "${online}" "${running}" "${POOL_COUNT}" "${settling}")" in
       unreachable)
         _rp_doctor_note "${p}: github could not be reached, so only local state is known: ${running}/${POOL_COUNT} running" ;;
+      starting)
+        _rp_doctor_note "${p}: started within the last ${RUNPOOL_SETTLE_SECS}s and has not reached github yet, which is normal; re-run doctor if it persists" ;;
       unregistered)
         _rp_doctor_fail "${p}: github has no runners registered for ${POOL_TARGET}, so every job routed here queues forever" \
                         "fix: runpool reregister ${p}   (github prunes registrations after a long idle spell)" ;;

--- a/runpool.conf.example
+++ b/runpool.conf.example
@@ -37,6 +37,13 @@
 # grace only avoids churn between rapid pushes in one working session.
 # RUNPOOL_IDLE_SECS=1200
 
+# How long after a pool starts before its runners are expected to have reached
+# GitHub. A runner opens its connection a second or two after launchd starts
+# it, and inside that window a healthy pool looks exactly like a broken one:
+# agents running locally, nothing online at GitHub. Reachability is not judged
+# until the window passes. Raise it if this machine starts runners slowly.
+# RUNPOOL_SETTLE_SECS=120
+
 # Load threshold exposed in structured status. It does not send an alert.
 # Defaults to six times core count, which sits clear of ordinary work.
 # Raise this as the pool grows: a busy pool of N runners reaches about N times

--- a/tests/pool-settling-window.sh
+++ b/tests/pool-settling-window.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# The rule that separates a pool which has just started from a broken one.
+#
+# A runner reaches GitHub a second or two after launchd starts it. Until it
+# does, a healthy pool presents exactly the numbers a broken one does: agents
+# up locally, nothing online at GitHub. `_rp_gh_state` is the single judgement
+# both `status` and the notifier read, so the distinction is tested here rather
+# than through either of them.
+set -uo pipefail
+
+repo_dir=$(cd -P "$(dirname "$0")/.." && pwd)
+scratch_dir=$(mktemp -d)
+trap 'rm -rf "${scratch_dir}"' EXIT INT TERM
+
+# Every path the library reads at load time points into a scratch directory, so
+# nothing here can see or touch a real installation.
+export RUNPOOL_BASE="${scratch_dir}/base"
+export RUNPOOL_STATE_DIR="${scratch_dir}/state"
+export RUNPOOL_CACHE_DIR="${scratch_dir}/cache"
+export RUNPOOL_CONFIG="${scratch_dir}/runpool.conf"
+export RUNPOOL_POOLS_FILE="${scratch_dir}/pools"
+export RUNPOOL_LOG_DIR="${scratch_dir}/logs"
+export RUNPOOL_LOG="${scratch_dir}/logs/runpool.log"
+export RUNPOOL_AGENT_DIR="${scratch_dir}/agents"
+mkdir -p "${RUNPOOL_BASE}" "${RUNPOOL_STATE_DIR}" "${RUNPOOL_CACHE_DIR}" \
+         "${RUNPOOL_LOG_DIR}" "${RUNPOOL_AGENT_DIR}"
+
+# shellcheck source=/dev/null
+. "${repo_dir}/lib/common.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+. "${repo_dir}/lib/scheduler.sh"
+
+mkdir -p "${RUNPOOL_POOL_STATE_DIR}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass=0
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass=$(( pass + 1 ))
+  else
+    fail "${label}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+# --- the state decision -----------------------------------------------------
+#             registered online running expected settling
+
+check "a pool up and connected is ok" \
+  "ok" "$(_rp_gh_state 3 3 3 3 0)"
+
+check "runners up and none online is offline once settled" \
+  "offline" "$(_rp_gh_state 3 0 3 3 0)"
+
+# The regression this file exists for. The same numbers, inside the window.
+check "the same numbers inside the settling window are a start, not an outage" \
+  "starting" "$(_rp_gh_state 3 0 3 3 1)"
+
+# A pruned registration is true regardless of how recently the pool started, so
+# the window must not swallow it: this is the failure that queues jobs forever.
+check "an unregistered pool still reports while settling" \
+  "unregistered" "$(_rp_gh_state 0 0 3 3 1)"
+
+check "an unreachable GitHub is never a pool fault, settling or not" \
+  "unreachable" "$(_rp_gh_state '?' '?' 3 3 1)"
+
+# Absent fifth argument means not settling, so an older caller cannot silently
+# turn every offline pool into a start.
+check "omitting the settling argument reports offline" \
+  "offline" "$(_rp_gh_state 3 0 3 3)"
+
+# --- the window itself ------------------------------------------------------
+
+_rp_pool_settling acme && fail "a pool that has never started is not settling"
+pass=$(( pass + 1 ))
+
+_rp_touch_pool_started acme
+_rp_pool_settling acme || fail "a pool started just now is settling"
+pass=$(( pass + 1 ))
+
+# Stamped further back than the window, which is how every pool spends all but
+# its first two minutes.
+echo "$(( $(_rp_now) - RUNPOOL_SETTLE_SECS - 1 ))" >| "$(_rp_pool_started_flag acme)"
+_rp_pool_settling acme && fail "a pool started before the window is not settling"
+pass=$(( pass + 1 ))
+
+# A truncated or hand-mangled stamp must not read as "started at the epoch"
+# and must not read as settling forever either.
+echo "not-a-number" >| "$(_rp_pool_started_flag acme)"
+_rp_pool_settling acme && fail "an unreadable stamp is not settling"
+pass=$(( pass + 1 ))
+
+echo "ok: ${pass} case(s)"


### PR DESCRIPTION
Closes #60.

The health check ran in the same tick as autoscale and asked GitHub whether any runner was online seconds after launchd had started them. A runner opens its connection a second or two later, so a healthy start presented exactly the numbers a broken pool does.

All three alerts this check has ever sent were that race, each firing one second before the runners reported `Listening for Jobs`.

## What changed

- `_rp_up` stamps when a pool came up. Every path that starts runners routes through it, so autoscale, `up`, `up-all` and a resize are all covered by the one stamp.
- Reachability is not judged until `RUNPOOL_SETTLE_SECS` (default 120) has passed. A new `starting` state carries that, so `status` shows `(just started; still connecting)` and `doctor` reports a note rather than a failure with a `reregister` remedy attached.
- `unregistered` deliberately still fires inside the window. A pruned registration is true regardless of how recently the pool started, and it is the failure that genuinely queues jobs forever, so the window must not swallow it.
- `_rp_health_check` now reads `_rp_gh_state` instead of its own inlined copy of the conditions. That duplication is why the notifier lacked a notion the rest of the tool could have given it.

A pool with no stamp reads as not settling, so an existing installation behaves exactly as it does today until its next start.

## Verification

`tests/pool-settling-window.sh`, 10 cases, wired into CI. It covers the state decision either side of the window, that an unregistered pool still reports while settling, that an unreachable GitHub is never a pool fault, that an absent fifth argument cannot silently turn every offline pool into a start, and that a mangled stamp reads as neither settling nor epoch.

Mutation-checked: with the settling argument ignored, the suite fails on the one assertion that matters and no other.

Full suite green, shellcheck clean at CI severity, bash 3.2 parse clean.