### PR TITLE
feat: cut a release by pushing an annotated tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Called by release.yml so a tag runs exactly the checks that gate main.
+  # Listing them a second time over there is how the two lists drift apart.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,240 @@
+name: Release
+
+# Cutting a release is one action: an annotated tag, pushed.
+#
+#   git tag -a v0.10.4      # the message is the release notes, see verify below
+#   git push origin v0.10.4
+#
+# Everything else happens here: the checks that gate main run again, a source
+# tarball is attached to a GitHub release, and the Homebrew formula in the tap
+# is bumped to point at it.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    # Hosted runners throughout, for the same reason ci.yml gives: this
+    # repository is public, and the tool it builds refuses to wire a public
+    # repo to a self-hosted pool. It would be absurd to break its own rule.
+    #
+    # This job is deliberately first and deliberately cheap. Both failures it
+    # catches are string comparisons, and catching them here means a bad tag
+    # costs seconds rather than a macOS runner.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The tag object itself is needed, not just the commit it points at.
+          fetch-depth: 0
+
+      - name: the tag and the version must agree
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          # RUNPOOL_VERSION in bin/runpool is the only place a version is
+          # written. The tag is a claim about it, checked here, because a tag
+          # without a matching bump ships a binary that misreports itself.
+          declared="$(sed -n 's/^RUNPOOL_VERSION="\(.*\)"$/\1/p' bin/runpool)"
+          if [ -z "${declared}" ]; then
+            echo "::error::could not read RUNPOOL_VERSION from bin/runpool"
+            exit 1
+          fi
+          if [ "${tag}" != "v${declared}" ]; then
+            echo "::error::tag ${tag} does not match RUNPOOL_VERSION=${declared} in bin/runpool"
+            echo "Bump the constant, commit it, then move the tag:"
+            echo "  git tag -d ${tag} && git push --delete origin ${tag}"
+            echo "  git tag -a ${tag} && git push origin ${tag}"
+            exit 1
+          fi
+          echo "ok  ${tag} matches RUNPOOL_VERSION=${declared}"
+
+      - name: the tag must carry the release notes
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          # The annotation is the single source of the release notes. There is
+          # no CHANGELOG.md by design and nothing is generated, so a lightweight
+          # tag would publish a release with nothing to read. cat-file is the
+          # honest test: for-each-ref quietly falls through to the commit
+          # message on a lightweight tag, which would look like it worked.
+          if [ "$(git cat-file -t "refs/tags/${tag}")" != "tag" ]; then
+            echo "::error::${tag} is a lightweight tag and carries no release notes"
+            echo "The tag message is the release notes. Re-cut it annotated:"
+            echo "  git tag -d ${tag} && git push --delete origin ${tag}"
+            echo "  git tag -a ${tag} && git push origin ${tag}"
+            exit 1
+          fi
+          if [ -z "$(git tag -l --format='%(contents:subject)' "${tag}")" ]; then
+            echo "::error::${tag} is annotated but its message is empty"
+            exit 1
+          fi
+          echo "ok  ${tag} carries an annotation"
+
+  ci:
+    needs: verify
+    # A tag can be pushed at any commit, including one that never passed CI.
+    # Calling ci.yml rather than restating its steps is what keeps the release
+    # gate and the main gate the same set of checks.
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    needs: [verify, ci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      sha256: ${{ steps.tarball.outputs.sha256 }}
+      tarball: ${{ steps.tarball.outputs.name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: build the source tarball
+        id: tarball
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          name="runpool-${version}.tar.gz"
+          # An uploaded asset rather than GitHub's archive/refs/tags URL. Those
+          # are generated on demand and their checksums are not contractually
+          # stable; a formula pinning one has been broken that way before.
+          # Hashing bytes we upload ourselves removes the class entirely.
+          # gzip -n drops the timestamp, so the same tag always builds the same
+          # tarball and the recorded sha256 stays explicable.
+          git archive --format=tar --prefix="runpool-${version}/" "${tag}" \
+            | gzip -n -9 >| "${name}"
+          sha="$(sha256sum "${name}" | cut -d' ' -f1)"
+          {
+            echo "name=${name}"
+            echo "sha256=${sha}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "built ${name}"
+          echo "sha256 ${sha}"
+
+      - name: take the release notes from the tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          # subject then body, rather than %(contents), so a signature block
+          # never lands in the notes.
+          {
+            git tag -l --format='%(contents:subject)' "${tag}"
+            body="$(git tag -l --format='%(contents:body)' "${tag}")"
+            if [ -n "${body}" ]; then
+              echo
+              printf '%s\n' "${body}"
+            fi
+          } >| notes.md
+          echo "--- notes.md ---"
+          cat notes.md
+
+      - name: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARBALL: ${{ steps.tarball.outputs.name }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          name="${TARBALL}"
+          # Idempotent, so re-running the whole workflow after a failure
+          # further down does not dead-end on an existing release.
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "release ${tag} exists, updating it"
+            gh release edit "${tag}" --notes-file notes.md
+            gh release upload "${tag}" "${name}" --clobber
+          else
+            gh release create "${tag}" "${name}" \
+              --title "${tag}" \
+              --notes-file notes.md \
+              --verify-tag
+          fi
+
+  tap:
+    needs: [release]
+    # macOS because the gate is brew itself: the formula is audited, built and
+    # tested here before anything is pushed, which is what the manual release
+    # checklist did by hand.
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: require the tap credential
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          if [ -z "${TAP_TOKEN}" ]; then
+            echo "::error::secrets.TAP_TOKEN is not set"
+            echo "A fine-grained PAT with Contents: write on the tap repository only."
+            exit 1
+          fi
+
+      - name: tap the formula repository
+        run: |
+          # Let brew clone it, so the working copy is already where brew
+          # expects a tap to live and can be audited and installed in place.
+          brew tap aicayzer/tap
+          brew --repo aicayzer/tap
+
+      - name: point the formula at this release
+        env:
+          SHA256: ${{ needs.release.outputs.sha256 }}
+          TARBALL: ${{ needs.release.outputs.tarball }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          tap="$(brew --repo aicayzer/tap)"
+          formula="${tap}/Formula/runpool.rb"
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/${TARBALL}"
+
+          python3 - "${formula}" "${url}" "${SHA256}" <<'PY'
+          import re, sys
+          path, url, sha = sys.argv[1:4]
+          src = open(path).read()
+          out, n_url = re.subn(r'^(\s*url\s+)"[^"]*"', lambda m: m.group(1) + '"%s"' % url,
+                               src, count=1, flags=re.M)
+          out, n_sha = re.subn(r'^(\s*sha256\s+)"[^"]*"', lambda m: m.group(1) + '"%s"' % sha,
+                               out, count=1, flags=re.M)
+          if n_url != 1 or n_sha != 1:
+              sys.exit("could not rewrite url/sha256 in %s" % path)
+          open(path, "w").write(out)
+          PY
+
+          git -C "${tap}" --no-pager diff -- Formula/runpool.rb
+
+      - name: audit, build and test the formula
+        run: |
+          # In this order on purpose: nothing is pushed until brew has actually
+          # installed and exercised the formula as edited.
+          brew audit --strict aicayzer/tap/runpool
+          brew install --build-from-source aicayzer/tap/runpool
+          brew test aicayzer/tap/runpool
+          # The whole point of the version guard, proven against what a user
+          # will actually install rather than against the source tree.
+          got="$(runpool version)"
+          if [ "${got}" != "runpool ${GITHUB_REF_NAME#v}" ]; then
+            echo "::error::installed binary reports '${got}', expected 'runpool ${GITHUB_REF_NAME#v}'"
+            exit 1
+          fi
+          echo "ok  ${got}"
+
+      - name: push the formula
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          tap="$(brew --repo aicayzer/tap)"
+          if git -C "${tap}" diff --quiet -- Formula/runpool.rb; then
+            echo "formula already points at ${tag}, nothing to push"
+            exit 0
+          fi
+          git -C "${tap}" config user.name "github-actions[bot]"
+          git -C "${tap}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${tap}" add Formula/runpool.rb
+          git -C "${tap}" commit -m "runpool ${tag}"
+          # The token goes on the remote rather than into the checkout, and the
+          # runner is thrown away after this step.
+          git -C "${tap}" remote set-url origin \
+            "https://x-access-token:${TAP_TOKEN}@github.com/aicayzer/homebrew-tap.git"
+          git -C "${tap}" push origin HEAD:main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,17 +128,27 @@ The pattern is already established: configuration precedence was found and fixed
 
 ## Releases
 
-1. **Bump `RUNPOOL_VERSION` in `bin/runpool`.** It is the only place the version is written, and the formula builds from a git tag, so a tag without a matching bump ships a binary that misreports itself.
-2. Land the change on `main` with CI green.
-3. `git tag -a vX.Y.Z` and push the tag.
-4. `gh release create vX.Y.Z` with notes describing what changed for a user.
-5. Update the Homebrew formula in the tap repository: bump `url` to the new tag and recompute `sha256` from the release tarball.
-6. `brew audit --strict` and `brew test` against the formula before pushing it.
+`.github/workflows/release.yml` does the whole of it. There are two manual steps:
 
-**There is no `CHANGELOG.md`, deliberately.** The release notes on GitHub are the changelog, the README's release badge links to them, and a copy in the repo would be a second thing to forget at step 4 and a second thing to disagree with the first. Do not add one.
+1. **Bump `RUNPOOL_VERSION` in `bin/runpool`** and land it on `main` with CI green. It is the only place a version is written.
+2. **Cut an annotated tag and push it.** `git tag -a vX.Y.Z` then `git push origin vX.Y.Z`.
+
+The workflow then re-runs the checks that gate `main`, attaches a source tarball to a GitHub release, and bumps the formula in the tap to point at it. Nothing else is done by hand.
+
+**The tag message is the release notes.** There is no second copy anywhere: no `CHANGELOG.md`, nothing generated from commits, nothing typed into the GitHub UI afterwards. Write them where you cut the tag, and keep them short. A reader wants to know what changed and whether it affects them; anyone who needs more than that can read the code. **The workflow refuses a lightweight tag** for this reason, and the check is `git cat-file -t` rather than `for-each-ref`, because `for-each-ref` falls through to the *commit* message on a lightweight tag and would publish something plausible and wrong.
+
+**The tag and `RUNPOOL_VERSION` must agree, and the workflow enforces it** before spending a macOS runner. A tag without a matching bump ships a binary that misreports itself, which was previously only a line in this file asking someone to remember.
+
+**The release asset is a tarball built here, not GitHub's `archive/refs/tags` URL.** Those are generated on demand and their checksums are not contractually stable, which has broken formulae pinning them. `git archive | gzip -n` is reproducible, and the recorded `sha256` is of bytes we uploaded.
+
+**The tap is updated last, and only after `brew audit --strict`, `brew install` and `brew test` pass against the edited formula.** That ordering is deliberate: if the tap step fails you have a real release and a stale formula, which is one job re-run away from fixed. The reverse would point the tap at a release that does not exist.
+
+**`secrets.TAP_TOKEN` is a fine-grained PAT with `Contents: write` on the tap repository only.** It is the one credential in the release path. Fine-grained PATs expire, and a silent expiry means a release that publishes but never reaches the tap, so the workflow fails loudly and early when the secret is missing rather than at `git push`.
+
+**There is no `CHANGELOG.md`, deliberately.** The release notes on GitHub are the changelog and the README's release badge links to them. A copy in the repo would be a second thing to keep current and a second thing to disagree with the first. Do not add one.
 
 **The formula installs `bin/` and `lib/` together under `libexec` and symlinks only the executable into `bin`.** The executable resolves its own location, following symlinks, to find `lib/` next to itself. Installing the script directly into `bin` puts `lib/` one directory too high and breaks it.
 
 ## This repository's own CI
 
-**Pinned to GitHub-hosted runners, permanently.** This repo is public, so a pull request from an untrusted fork runs its own workflow file. RunPool refuses to register a public repository for exactly that reason, and it would be absurd for the tool to break its own rule. `--allow-public` exists for users who have weighed the risk on their own machine; it is not licence to point this repository at a pool.
+**Pinned to GitHub-hosted runners, permanently. This applies to `release.yml` as much as to `ci.yml`.** This repo is public, so a pull request from an untrusted fork runs its own workflow file. RunPool refuses to register a public repository for exactly that reason, and it would be absurd for the tool to break its own rule. `--allow-public` exists for users who have weighed the risk on their own machine; it is not licence to point this repository at a pool.

--- a/bin/runpool
+++ b/bin/runpool
@@ -43,7 +43,7 @@ export RUNPOOL_INVOKED
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.10.3"
+RUNPOOL_VERSION="0.10.4"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"


### PR DESCRIPTION
Releasing was six manual steps in `AGENTS.md` and the tap update was the one most easily forgotten. `main` currently sits four commits ahead of the installed 0.10.3 with the #61 health-check fix in it that no machine has.

Pushing an annotated tag now does the rest.

## What it does

| Job | |
|---|---|
| `verify` | Tag matches `RUNPOOL_VERSION`; tag is annotated. Both are string checks, first, so a bad tag costs seconds not a macOS runner. |
| `ci` | Calls `ci.yml` as a reusable workflow rather than restating its steps. |
| `release` | Reproducible `git archive` tarball, attached to a release whose notes are the tag message. |
| `tap` | Rewrites `url` + `sha256`, runs `brew audit --strict` / `install` / `test`, **then** pushes. |

## Decisions worth flagging

**The tag message is the release notes, and the only copy.** No `CHANGELOG.md`, nothing generated, nothing typed into the UI afterwards. A lightweight tag is refused, and the check is `git cat-file -t` rather than `for-each-ref` — the latter falls through to the *commit* message on a lightweight tag, so the release would publish something plausible and wrong. Verified locally that it does exactly that.

**The asset is built here, not GitHub's `archive/refs/tags` URL.** Those are generated on demand and their checksums are not contractually stable, which has broken formulae pinning them. `git archive | gzip -n` is reproducible — confirmed byte-identical across builds — and the recorded `sha256` is of bytes we uploaded.

**Release before tap, deliberately.** A tap failure leaves a real release and a stale formula, one job re-run from fixed. The reverse would point the tap at a release that does not exist.

**Hosted runners throughout**, same reason `ci.yml` already gives. `AGENTS.md` now says this covers `release.yml` too.

## Needs before a tag will complete

`secrets.TAP_TOKEN` — a fine-grained PAT with `Contents: write` on `homebrew-tap` only. The job fails loudly and early if it is missing rather than at `git push`.