### PR TITLE
fix: read the tag annotation checkout has not yet clobbered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,18 @@ jobs:
           # The tag object itself is needed, not just the commit it points at.
           fetch-depth: 0
 
+      - name: restore the annotated tag object
+        # actions/checkout fetches the real tag and then force-updates
+        # refs/tags/<tag> to point straight at the commit it was told to check
+        # out, which leaves a lightweight tag behind:
+        #   git fetch ... +refs/tags/*:refs/tags/*      <- the annotated object
+        #   git fetch ... +<sha>:refs/tags/<tag>        <- clobbers the ref
+        # Everything below reads the annotation, so fetch the ref back before
+        # trusting it. Without this the release notes silently become the
+        # commit message, which is precisely the failure the next step exists
+        # to catch.
+        run: git fetch --force origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+
       - name: the tag and the version must agree
         run: |
           tag="${GITHUB_REF_NAME}"
@@ -93,6 +105,18 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: restore the annotated tag object
+        # actions/checkout fetches the real tag and then force-updates
+        # refs/tags/<tag> to point straight at the commit it was told to check
+        # out, which leaves a lightweight tag behind:
+        #   git fetch ... +refs/tags/*:refs/tags/*      <- the annotated object
+        #   git fetch ... +<sha>:refs/tags/<tag>        <- clobbers the ref
+        # Everything below reads the annotation, so fetch the ref back before
+        # trusting it. Without this the release notes silently become the
+        # commit message, which is precisely the failure the next step exists
+        # to catch.
+        run: git fetch --force origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
 
       - name: build the source tarball
         id: tarball


### PR DESCRIPTION
Closes #63.

`actions/checkout` force-updates `refs/tags/<tag>` to the commit after fetching the real tag, so both jobs that read the annotation were reading a lightweight tag.

`verify` refused `v0.10.4` on its first real use. The quieter half is that `release` would have published `feat: cut a release by pushing an annotated tag (#62)` as the notes — the guard against exactly that was defeated by the same mechanism.

Fix is a re-fetch of the tag ref in both jobs. Reproduced and verified against a clean clone: `commit` after simulating checkout's second fetch, `tag` with the right annotation after the re-fetch.