### PR TITLE
fix: repair a moved runner's links when re-registering it

### DIFF
--- a/bin/runpool
+++ b/bin/runpool
@@ -43,7 +43,7 @@ export RUNPOOL_INVOKED
 # The released version, and the only place it is written. The Homebrew formula
 # builds from a git tag, so a tag without a matching bump here ships a binary
 # that misreports itself.
-RUNPOOL_VERSION="0.12.1"
+RUNPOOL_VERSION="0.12.2"
 
 # shellcheck source=lib/common.sh
 . "${RUNPOOL_ROOT}/lib/common.sh"

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -493,6 +493,12 @@ _rp_reregister_locked() {
     rm -f "${runner_dir}/.runner" "${runner_dir}/.credentials" \
           "${runner_dir}/.credentials_rsaparams" "${runner_dir}/.runner_migrated" \
           "${runner_dir}/.service"
+    # reregister is the repair command, and a runner whose directory has been
+    # moved has absolute bin and externals links pointing where it used to be.
+    # config.sh cannot start against those, so repairing them is part of
+    # repairing the install rather than a separate errand. Relative links are
+    # already correct, so this is a no-op on a healthy runner.
+    _rp_rewrite_runner_links "${runner_dir}" || return 1
     _rp_log "${name} runner-${i}: re-registering as '${runner_name}'"
     ( cd "${runner_dir}" && ./config.sh --unattended --replace \
         --url "https://github.com/${POOL_TARGET}" --token "${token}" \

--- a/tests/pool-rename.sh
+++ b/tests/pool-rename.sh
@@ -273,4 +273,26 @@ ok
 ok
 rm -rf "${RUNPOOL_STATE_DIR}/resize.bravo.lock"
 
+# ---------------------------------------------------------------------------
+# reregister repairs a moved install
+# ---------------------------------------------------------------------------
+# The documented recovery from a rename that failed part way, so it has to
+# cope with the dangling links that failure leaves behind.
+build_pool alpha 1
+mv "${RUNPOOL_BASE}/runners/alpha" "${RUNPOOL_BASE}/runners/moved"
+sed -i '' "s|runners/alpha|runners/moved|" "${RUNPOOL_BASE}/pools/alpha.conf"
+(
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/common.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  . "${repo_dir}/lib/lifecycle.sh"
+  _rp_down() { return 0; }
+  _rp_busy_in() { echo 0; }
+  _rp_reregister alpha
+) >"${scratch_dir}/out" 2>&1 || fail "reregister did not repair a moved install: $(cat "${scratch_dir}/out")"
+case "$(readlink "${RUNPOOL_BASE}/runners/moved/runner-1/bin")" in
+  /*) fail "reregister left an absolute bin link" ;;
+  *) ok ;;
+esac
+
 echo "ok: ${pass} case(s)"


### PR DESCRIPTION
Follow-up to #73.

`reregister` is the documented recovery from a `rename` that failed part way, and that failure leaves the runner directories moved with their `bin` and `externals` links still pointing where they used to be. `config.sh` cannot start against those, so the recovery command hit the same wall as the thing it was recovering from.

Repairing the links is part of repairing the install rather than a separate errand, and it is a no-op on a healthy runner whose links are already relative.

Covered by a case that moves an install behind the tool's back and asserts `reregister` both succeeds and leaves the link relative.